### PR TITLE
Add SPEC tags

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ theme = "mainroad"
 
 [Params]
   mainSections = ["_index"]
+  post_meta = ["author", "date", "spec_fields"]
 
 [Params.logo]
   title = "The Scientific Python Ecosystem" # Logo title, otherwise will use site title

--- a/content/specs/spec-template.md
+++ b/content/specs/spec-template.md
@@ -1,18 +1,14 @@
 ---
 title: "SPEC X --- Template and Instructions"
+author: "<list of authors' real names and optionally, email addresses>"
 date: 2020-12-17T20:40:16-08:00
 draft: false
 summary: |
   Template and instructions for writing new SPECs.
+
+spec_status: 'Draft | Active | Accepted | Deferred | Rejected | Withdrawn | Final | Superseded'
+spec_type: 'Standards Track | Process'
 ---
-
-
-    :Author: <list of authors' real names and optionally, email addresses>
-    :Status: <Draft | Active | Accepted | Deferred | Rejected |
-             Withdrawn | Final | Superseded>
-    :Type: <Standards Track | Process>
-    :Created: <date created on, in dd-mmm-yyyy format>
-
 
 Abstract
 ========

--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -1,0 +1,6 @@
+{{- if isset .Params "author" -}}
+<div class="meta__item-author meta__item">
+	{{ partial "svg/author.svg" (dict "class" "meta__icon") -}}
+	<span class="meta__text">{{ .Params.author }}</span>
+</div>
+{{- end -}}

--- a/layouts/partials/post_meta/spec_fields.html
+++ b/layouts/partials/post_meta/spec_fields.html
@@ -1,0 +1,10 @@
+{{- if isset .Params "author" -}}
+<div class="meta__item-spec-field">
+  {{ partial "svg/tag.svg" (dict "class" "meta__icon") -}}
+  <b>Type:</b> <span class="meta__text">{{ .Params.spec_type }}</span>
+</div>
+<div class="meta__item-spec-field">
+  {{ partial "svg/tag.svg" (dict "class" "meta__icon") -}}
+  <b>Status: </b> <span class="meta__text">{{ .Params.spec_status }}</span>
+</div>
+{{- end -}}


### PR DESCRIPTION
This is a proof of concept of adding tags to SPEC rendering.

TODO:

- [ ] Iterate through tags without naming each explicitly
- [ ] Do not show tags in summary (maybe status, author, and date?)
- [ ] Render specs differently from other posts (tags underneath one another, instead of in a row—could be done by moving all spec fields into `spec_*`)
