### PR TITLE
CI: setup circle CI for building/previewing PRs

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,1 +1,1 @@
-0/publish/index.html
+0/public/index.html

--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+0/publish/index.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.0
+
+jobs:
+  build:
+    working_directory: ~/repo
+    docker:
+      # Docker image with Go pre-installed to make hugo install easier
+      - image: cimg/go:1.15.6
+
+    steps:
+      - checkout
+
+      - run:
+          name: Update apt-get
+          command: sudo apt-get update
+
+      - run:
+          name: Install hugo
+          command: sudo apt-get install hugo
+
+      - run:
+          name: Install hugo theme
+          command: git submodule update --init
+
+      - run:
+          # TODO: include --buildDrafts?
+          name: Build site
+          command: hugo
+
+      - store_artifacts:
+          path: public/

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ title = "Scientific Python Ecosystem"
 subtitle = "Planning for the next decade"
 theme = "mainroad"
 uglyurls = true
+relativeURLs=true
 
 [Params]
   mainSections = ["_index"]

--- a/content/specs/spec-0001.md
+++ b/content/specs/spec-0001.md
@@ -112,4 +112,4 @@ discussed before any vote is taken.  The workflow of a SPEC is detailed
 [here]({{< ref "/specs/spec-0000.md" >}}).
 
 A list of all existing SPECs is available [here]({{< ref
-"/specs/" >}}).
+"/specs/_index.md" >}}).


### PR DESCRIPTION
Uses CircleCI + the artifact redirector app so that changes to the site can be previewed during the review process.

TODO (needs member of scientific-python org with admin privileges):
 - [x] Activate circleCI for this project
 - [x] Add the [artifact redirector app](https://github.com/apps/circleci-artifacts-redirector/) to this repo

A couple other things: 
 - The site failed to build on CI without abbbd1f, though it works fine locally. My guess is this is related to the hugo version - I think it's fairly common to experience problems related to hugo version number.
 - Previewing locally via artifacts requires the the `relativeURLs=true` config option. I added this directly to the config.toml in 5325bd5, but this may interfere with the deployment. Instead, it may be better to inject this line into the `config.toml` during the CircleCI build.