### PR TITLE
Add shortcode for embedding charts via mermaid.

### DIFF
--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,0 +1,5 @@
+<!-- TODO: Move the script out of the shortcode -->
+<script async src="https://unpkg.com/mermaid@8.2.3/dist/mermaid.min.js"></script>
+<div class="mermaid">
+  {{.Inner}}
+</div>


### PR DESCRIPTION
Adds a hugo shortcode to enable embedded charts with [mermaid](https://mermaid-js.github.io/mermaid/#/).

With this shortcode, users can create charts with mermaid directly in the markdown files using the `{{<mermaid>}}` tag, like so:
```
{{<mermaid>}}
graph TD;
  A-->B;
{{</mermaid>}}
```

The TODO is related to recommendations in tutorials to move the `<script>` tag out of the shortcode and instead put it in a relevant partial layout with a conditional so that the resource is only loaded on pages where it is necessary. See e.g. [this tutorial](https://codewithhugo.com/mermaid-js-hugo-shortcode/).