### PR TITLE
Add a page-based gallery

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -138,6 +138,38 @@ table.spec__table thead {
   flex-wrap: wrap;
 }
 
+.gallery .entry {
+  padding: 1rem;
+  margin: 0.25rem;
+  width: 11rem;
+  text-align: center;
+  vertical-align: top;
+}
+
+.gallery .photo {
+  display: block;
+}
+
+.gallery .photo img {
+    width: 60px;
+    border-radius: 50%;
+    margin-bottom: 0.5rem;
+}
+
+.gallery .name {
+    font-weight: bold;
+}
+
+.gallery .project {
+  display: block;
+  font-size: 0.8rem;
+  font-style: italic;
+}
+
+/* this should be removed once galleries are made more generic */
+/* | */
+/* v */
+
 .person {
   padding: 1rem;
   margin: 0.25rem;
@@ -165,6 +197,8 @@ table.spec__table thead {
   font-size: 0.8rem;
   font-style: italic;
 }
+
+/* stop removing here */
 
 .endorsed-specs {
   padding-top: 1rem;

--- a/layouts/shortcodes/page_gallery.html
+++ b/layouts/shortcodes/page_gallery.html
@@ -1,0 +1,17 @@
+<div class="gallery">
+  {{ $section := .Page.GetPage (.Get 0) }}
+  {{ range $section.Pages }}
+    <div class="entry">
+      <a href="{{ .Params.repository }}" class="name">
+        <div class="photo">
+          <img
+            src="{{ default (relURL "/img/avatar.png") (.Params.avatar) }}"
+            loading="lazy"
+            alt="Avatar of {{ .Title }}"
+          />
+        </div>
+        {{ .Title }}
+      </a>
+    </div>
+  {{ end }}
+</div>


### PR DESCRIPTION
This gallery generates its entries from the metadata of pages in a
specific page / category.

Usage:

```
  {{< page_gallery "." >}}
```

Where "." is the relative URL to the category.