### PR TITLE
Remove installation methods other than pip and conda from install article

### DIFF
--- a/content/en/ecosystem/install.md
+++ b/content/en/ecosystem/install.md
@@ -4,32 +4,27 @@ youtube_id:
 draft: false
 ---
 
-Installations methods include:
+There are many different ways to install scientific Python packages. We'll
+focus on two recommended methods, specifically:
 
-- Distributions
-- pip
-- Package Manager
-- Source
-- Binaries
+- `pip` (with the builtin `venv` module for virtual environments.
+- `conda`
 
-Methods differ in ease of use, coverage, maintenance of old versions,
-system-wide versus local environment use, and control.
-With pip or Anaconda's conda, you can control the package versions for a specific
-project to prevent conflicts.
-Conda also controls non-Python packages, like MKL or HDF5.
-System package managers, like `apt-get`, install
-across the entire computer, often have older versions, and don't have
-as many available versions.
-Source compilation is much more difficult but is necessary for debugging and development.
-If you don't know which installation method you need or prefer, we recommend the Scientific
-Python Distribution [Anaconda](https://www.anaconda.com/download/) .
+Both `pip` and `conda`, you can control the package versions for a specific
+project to prevent dependency conflicts.
+One of the advantages of `pip` is that it is a built-in module of Python and
+therefore is ubiquitous and well-supported.
+`conda` is a more extensive package manager, which includes the ability to
+install and manage non-Python packages, like MKL or HDF5.
+`conda` also doubles as an *environment manager*, allowing users to create and
+manage different *virtual environments* for their Python projects.
 
 ## Scientific Python Distributions (recommended) {#distributions}
 
 Python distributions provide the language itself, along with the most
 commonly used packages and tools.
 These downloadable files require little configuration, work on almost all setups,
-and provide all the commonly used scientific python tools.
+and provide all the commonly-used scientific Python packages.
 
 [Anaconda](https://www.anaconda.com/download/) works on Windows, Mac, and Linux,
 provides over 1,500 Python/R packages, and is used by over 15 million people.
@@ -40,82 +35,27 @@ For more advanced users who will need to install or upgrade regularly,
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a more
 suitable way to install the _conda_ package manager.
 
-Other options include:
+Once the `conda` package manager has been installed and configured, installing
+packages from the scientific Python ecosystem is quite simple, for example:
 
-- [WinPython](https://winpython.github.io): Another free distribution
-  including scientific packages and the Spyder IDE; Windows only, but
-  more actively maintained and supports the latest Python 3 versions.
-- [Pyzo](http://www.pyzo.org/): A free distribution based on Anaconda
-  and the IEP interactive development environment; Supports Linux,
-  Windows, and Mac.
+    conda install numpy scipy matplotlib ipython jupyter pandas sympy
 
 ## Installing via pip {#pip-install}
 
-Python comes with an inbuilt package management system,
+Python comes with a built-in package management system,
 [pip](https://pip.pypa.io/en/stable).
 Pip can install, update, or delete any official package.
 
 You can install packages via the command line by entering:
 
-    python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
+    python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy
 
-We recommend using an _user_ install, sending the `--user` flag to pip.
-`pip` installs packages for the local user and does not write to the system directories.
-Preferably, do not use `sudo pip`, as this combination can cause problems.
+The `--user` flag is useful to avoid conflicts with system-level Python packages
+and to circumvent the need to have administrator priviledges to install packages.
 
-Pip accesses the Python Package Index, [PyPI](https://pypi.org/), which
-stores almost 200,000 projects and all previous releases of said
-projects.
-Because the repository keeps previous versions, you can pin to
+Pip accesses the Python Package Index, [PyPI](https://pypi.org/) which
+stores almost 200,000 projects, including all the packages of the scientific
+Python ecosystem.
+PyPI provides the current released versions of all packages, as well as previous
+versions, so you can pin to
 a version and not worry about updates causing conflicts.
-Pip can also install packages in local _virtualenv_, or virtual environment.
-
-## Install system-wide via a package manager
-
-System package managers can install the most common Python packages.
-They install packages for the entire computer, often use older versions,
-and don't have as many available versions.
-
-### Ubuntu and Debian
-
-using apt-get:
-
-    sudo apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose
-
-### Fedora 22 and later
-
-using dnf:
-
-    sudo dnf install numpy scipy python-matplotlib ipython python-pandas sympy python-nose atlas-devel
-
-### Mac
-
-Mac doesn't have a preinstalled package manager, but there are a couple
-of popular package managers you can install.
-
-For Python 3.5 with [Macports](https://www.macports.org) , execute this
-command in a terminal:
-
-    sudo port install py35-numpy py35-scipy py35-matplotlib py35-ipython +notebook py35-pandas py35-sympy py35-nose
-
-[Homebrew](https://brew.sh/) has an incomplete coverage of the SciPy
-ecosystem, but does install these packages:
-
-    brew install numpy scipy ipython jupyter
-
-## Source packages
-
-You can build any of the packages from source.
-Those involved in development may take this route to get developmental versions or alter source code.
-Refer to individual projects for more details.
-
-## Binaries
-
-Binary files can directly install the packages.
-These can either come from the direct source, like [GitHub](https://github.com/) or
-[PyPI](https://pypi.org/), or third-party repositories.
-Linux operating systems, like [Ubuntu](https://packages.ubuntu.com/), have package
-repositories where you can search for and download individual binaries.
-For Windows, Christoph Gohlke provides
-[pre-built Windows installers](http://www.lfd.uci.edu/~gohlke/pythonlibs)
-for many packages.


### PR DESCRIPTION
Removes the text related to installing packages with system package managers, source, or binaries.

Addresses some of the bullets in #103.