### PR TITLE
Allow adjusting indentation level of YouTube videos

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -12,21 +12,21 @@ underrepresented in STEM and the open source scientific Python community.
 
 Community members must adhere to our [code of conduct]({{< relref "/code_of_conduct.md" >}}).
 
-# Diversity, Equity, and Inclusion
+## Diversity, Equity, and Inclusion
 
 - [Diversity & Inclusion in Scientific Computing (DISC) group](https://numfocus.org/programs/diversity-inclusion)
 - [Advancing an inclusive culture in the scientific Python ecosystem]({{< relref "/inclusive_culture" >}})
 
-# How to contribute
+## How to contribute
 
 The scientific Python ecosystem welcomes your expertise and enthusiasm!
 
-{{< youtube_page "ecosystem-expectations" >}}
+{{< youtube_page page="ecosystem-expectations" levelOffset=3 >}}
 
-{{< youtube_page "why-contribute" >}}
+{{< youtube_page page="why-contribute" levelOffset=3 >}}
 
-{{< youtube_page "getting-started" >}}
+{{< youtube_page page="getting-started" levelOffset=3 >}}
 
-{{< youtube_page "ways-to-contribute" >}}
+{{< youtube_page page="ways-to-contribute" levelOffset=3 >}}
 
-{{< youtube_page "my-first-contribution" >}}
+{{< youtube_page page="my-first-contribution" levelOffset=3 >}}

--- a/content/en/ecosystem/_index.md
+++ b/content/en/ecosystem/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Ecosystem"
 draft: false
+shortcutDepth: 1
 ---
 
 Here are some useful links:
@@ -8,9 +9,8 @@ Here are some useful links:
 - [cookbook](https://scipy-cookbook.readthedocs.io/)
 - [blogs](https://planet.scipy.org/)
 
-{{< youtube_page "ecosystem-introduction" >}}
+{{< youtube_page page="ecosystem-introduction" levelOffset=2 >}}
 
-{{< youtube_page "ecosystem/install" >}}
+{{< youtube_page page="ecosystem/install" levelOffset=2 >}}
 
-{{< youtube_page "ecosystem/next-steps" >}}
-
+{{< youtube_page page="ecosystem/next-steps" levelOffset=2 >}}

--- a/content/en/news/specs-announced-scipy2021/_index.md
+++ b/content/en/news/specs-announced-scipy2021/_index.md
@@ -11,4 +11,4 @@ sidebar: false
 Stéfan van der Walt announces the Scientific Python Ecosystem Coordination project and
 talks about the SPEC documents during SciPy 2021.
 
-{{< youtube_page "video" >}}
+{{< youtube_page page="video" >}}

--- a/layouts/shortcodes/youtube_page.html
+++ b/layouts/shortcodes/youtube_page.html
@@ -1,16 +1,49 @@
-{{ $page := .Page.GetPage (.Get 0) }}
+{{ $page := .Page.GetPage (.Get "page") }}
 
 {{ $id := $page.Params.youtube_id }}
 {{ $title := $page.Params.title }}
 {{ $venue := $page.Params.venue }}
 {{ $authors := $page.Params.authors }}
 {{ $date := $page.Params.date }}
-{{ $transcript := $page.Content }}
+
+{{ $transcript := $page.RawContent }}
+
+{{/* Adjust the indentation of the transcript according to levelOffset */}}
+{{/* See https://discourse.gohugo.io/t/option-to-shift-headings/6136/2 */}}
+
+{{ $levelOffset := default 2 (.Get "levelOffset") }}
+
+{{/* get the Markdown without front matter  */}}
+{{ $s := $transcript }}
+
+{{/* the regex of start of line `^` doesn't work. (GoLang has a subset of regex)
+     Need to specify newlines via `\n`
+     Need to ensure  newlines at start and end of content */}}
+{{ $s :=  delimit (slice "\n" $s "\n") "" }}
+
+{{/*
+Search for any Markdown headings `#` at start of line
+and add (levelOffset - 2) `#`s to start of line.
+
+Why -1? Because the offsetLevel specifies the level for the title.
+Other headings start with ##, ###, etc.
+We want to shift the content so that it is one deeper than the title,
+and since there are already two, we need to add a further
+(levelOffset - 1) hashes.
+*/}}
+
+{{ $header_padding := (strings.Repeat (sub $levelOffset 1) "#") }}
+{{ $new_header := (printf "\n%s$1 " $header_padding) }}
+{{ $s := $s | replaceRE "\n(#+) " $new_header }}
+
+{{/* render the Markdown to HTML
+     declare it to be safe HTML and return */}}
+{{ $transcript := $s | markdownify | safeHTML }}
 
 <div class="youtube">
-  <h2 class="video-title">
+  <h{{ $levelOffset }} class="video-title">
     {{ $title }}
-  </h2>
+  </h{{ $levelOffset }}>
   <iframe src="https://www.youtube.com/embed/{{ $id }}?enablejsapi=1&modestbranding=0" allowfullscreen class="youtube"></iframe>
   {{ if $transcript }}
   <button type="button" class="yp-video-transcript-button video-transcript-button">


### PR DESCRIPTION
This does some surgery on the caption Markdown to ensure that the
headers fit into the structure of the page.  The depth has to be
specified by hand as as `levelOffset` parameter to the `youtube_page`
shortcode.

Combined with https://github.com/scientific-python/scientific-python-hugo-theme/pull/59, this should render the shortcut links on the video pages correctly.