### PR TITLE
Reorganize community/ecosystem introduction videos

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -21,12 +21,12 @@ Community members must adhere to our [code of conduct]({{< relref "/code_of_cond
 
 The scientific Python ecosystem welcomes your expertise and enthusiasm!
 
-{{< youtube_page page="ecosystem-expectations" levelOffset=3 >}}
-
 {{< youtube_page page="why-contribute" levelOffset=3 >}}
-
-{{< youtube_page page="getting-started" levelOffset=3 >}}
 
 {{< youtube_page page="ways-to-contribute" levelOffset=3 >}}
 
+{{< youtube_page page="getting-started" levelOffset=3 >}}
+
 {{< youtube_page page="my-first-contribution" levelOffset=3 >}}
+
+{{< youtube_page page="ecosystem-expectations" levelOffset=3 >}}

--- a/content/en/community/ecosystem-expectations.md
+++ b/content/en/community/ecosystem-expectations.md
@@ -1,5 +1,5 @@
 ---
-title: "Welcome to the community"
+title: "Where to contribute: choosing a project"
 youtube_id:
 draft: false
 ---
@@ -8,15 +8,17 @@ draft: false
 
 ## Contributing to Open Source: Know your community
 
-You might be wondering what "open source software" refers to exactly.
-In broad terms, open source software is any software whose source code is publicly available and viewable.
-The level of “openness” varies based on the project: for some it is only source code available without necessarily engaging with the community while for others the community is heavily involved in making decisions, contributing, and more.
+A common question from new contributors is: "how do I choose which project to
+contribute to"?
+Some people end up contributing to many different projects, whereas others
+tend to focus their effort on a single project.
+Ultimately, the most important factors in this decision are your own personal
+goals and interests!
+The projects in the ecosystem have a lot in common; however, it is important to
+recognize the each project has it's own community, so there may be differences
+in the overall goals and decision-making processes for each project.
 
-The open source Scientific Python  community functions differently from a normal work environment because it is largely comprised of people contributing from different timezones in their free time.
-As such, it’s important to recognize that contributors and maintainers may not always be consistent when they’re able to work or get back to you.
-
-Since so many members are volunteers, any and all contributions are highly valued.
-Sometimes people may miss out on notifications or read something and forget to respond, so if you haven’t heard back from them in a few days, it’s usually safe to ping them to check that they didn’t miss anything.
+## Understanding the project
 
 Depending on the amount of dependents of a project, it can be more difficult to contribute to as there is a more vigorous review process since your contributions will affect a large amount of people.
 It’s not uncommon for even core developers to have pull requests going through iterations for years before being merged.
@@ -27,3 +29,24 @@ It is then discussed and iterated on before a decision is made.
 
 On the other hand, small projects such as (insert something here) may just require a review or two and basic tests before your changes are merged.
 This is important to keep in mind when picking out a project to work on.
+
+## Contributing to the ecosystem
+
+The open source Scientific Python community functions differently from a normal work environment because it is largely comprised of people contributing from different timezones in their free time.
+As such, it’s important to recognize that contributors and maintainers may not always be consistent when they’re able to work or get back to you.
+
+Since so many members are volunteers, any and all contributions are highly valued.
+Sometimes people may miss out on notifications or read something and forget to respond, so if you haven’t heard back from them in a few days, it’s usually safe to ping them to check that they didn’t miss anything.
+
+## Learn more about a project
+
+Getting to know the developer community is a great way to learn more about the
+projects and find a great fit.
+There are many ways to begin interacting with project communities:
+ - Most projects have a developer mailing list.
+ - Many projects also have other communication channels for developers and
+   newcomers, such as slack and discord.
+ - Projects often have community meetings for developers or newcomers.
+ - Consider [watching a project on GitHub][gh-watching].
+
+[gh-watching]: https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/managing-subscriptions-for-activity-on-github/viewing-your-subscriptions

--- a/content/en/community/ecosystem-expectations.md
+++ b/content/en/community/ecosystem-expectations.md
@@ -21,13 +21,6 @@ Sometimes people may miss out on notifications or read something and forget to r
 Depending on the amount of dependents of a project, it can be more difficult to contribute to as there is a more vigorous review process since your contributions will affect a large amount of people.
 It’s not uncommon for even core developers to have pull requests going through iterations for years before being merged.
 
-![Scientific Python Ecosystem](/images/ecosystem.svg)
-
-(show visual; also correct this as needed) This is roughly the atomic arrangement of the ecosystem.
-At the very center is NumPy, followed by other foundational libraries in the next ring such as SciPy, scikit-learn, pandas, dask, jupyter, etc.
-Further out are other libraries built on them such as PyTorch, Tensorflow, and more.
-At the fringe are small projects with few dependents such as (insert something here).
-
 Because NumPy affects pretty much the entire ecosystem, it is going to be very difficult to contribute larger features to and usually requires a NumPy Enhancement Proposal (NEP) to be approved before work is started on it.
 Enhancement Proposals are fairly common for core projects in the ecosystem and consist of a writeup of the planned changes, including a summary of the implementation, pros and cons of it, and sometimes a proof of concept coded up.
 It is then discussed and iterated on before a decision is made.

--- a/content/en/ecosystem/ecosystem-introduction.md
+++ b/content/en/ecosystem/ecosystem-introduction.md
@@ -12,8 +12,11 @@ software packages that bring powerful features for scientific computing to the
 Python programming language. There is no central authority that determines
 which projects are considered members; rather, the ecosystem has grown orgranically
 from a small collection of core packages to encompass a broad and ever expanding
-collection of projects. The foundational packages from which the ecosystem has
-grown include:
+collection of projects.
+
+![Scientific Python Ecosystem](/images/ecosystem.svg)
+
+The foundational packages from which the ecosystem has grown include:
 
 - [NumPy](http://www.numpy.org/), the fundamental package for
   numerical computation. NumPy defines the n-dimensional array data structure,


### PR DESCRIPTION
The `ecosystem-expectations` script has a lot of information about both the ecosystem and individual projects. I only noticed this when looking at the scripts *in context* with all the others on the website, but I thought that the `ecosystem-expecations` didn't quite fit in with the other contribution videos on the community page. The info in the transcript is generally useful, but I thought it might be more clear to move some of the info over to the ecosystem introduction and to slightly shift the focus of the `ecosystem-expectations` more towards the individual projects.

A quick summary:
 - Move the ecosystem visualization from the 'community' page to the 'ecosystem' page
 - Re-order the videos about contribution on the community page, starting with the motivation ("why should I contribute"), then the "how", followed by "getting started" and finally the "first contribution walkthrough".
 - Also renamed/reorganized the "welcome to the community" transcript to more of a "choosing a project to contribute to". I tried to preserve a lot of the good info from the original transcript and I'd defintely like to take another crack at it to tighten it up.