### PR TITLE
Reorganize content in ecosystem/install transcript

### DIFF
--- a/content/en/ecosystem/install.md
+++ b/content/en/ecosystem/install.md
@@ -50,5 +50,3 @@ and to circumvent the need to have administrator priviledges to install packages
 Pip accesses the Python Package Index, [PyPI](https://pypi.org/) which
 stores almost 200,000 projects, including all the packages of the scientific
 Python ecosystem.
-PyPI provides the current released versions of all packages, as well as previous
-versions, so you can pin to a version and not worry about updates causing conflicts.

--- a/content/en/ecosystem/install.md
+++ b/content/en/ecosystem/install.md
@@ -22,21 +22,12 @@ libraries like MKL or HDF5.
 `conda` also doubles as an *environment manager*, allowing users to create and
 manage different *virtual environments* for their Python projects.
 
-## Scientific Python Distributions (recommended) {#distributions}
+## Installing with conda {#distributions}
 
-Python distributions provide the language itself, along with the most
-commonly used packages and tools.
-These downloadable files require little configuration, work on almost all setups,
-and provide all the commonly-used scientific Python packages.
-
-[Anaconda](https://www.anaconda.com/download/) works on Windows, Mac, and Linux,
-provides over 1,500 Python/R packages, and is used by over 15 million people.
-Anaconda is best suited to beginning users; it provides
-a large collection of libraries all in one.
-
-For more advanced users who will need to install or upgrade regularly,
-[Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a more
-suitable way to install the _conda_ package manager.
+In order to use `conda`, it needs to be installed on your system.
+The simplest way to install the `conda` package manager is with the
+[Miniconda](https://docs.conda.io/en/latest/miniconda.html) minimal installer
+package.
 
 Once the `conda` package manager has been installed and configured, installing
 packages from the scientific Python ecosystem is quite simple, for example:
@@ -60,5 +51,4 @@ Pip accesses the Python Package Index, [PyPI](https://pypi.org/) which
 stores almost 200,000 projects, including all the packages of the scientific
 Python ecosystem.
 PyPI provides the current released versions of all packages, as well as previous
-versions, so you can pin to
-a version and not worry about updates causing conflicts.
+versions, so you can pin to a version and not worry about updates causing conflicts.

--- a/content/en/ecosystem/install.md
+++ b/content/en/ecosystem/install.md
@@ -17,7 +17,8 @@ project to prevent dependency conflicts.
 One of the advantages of `pip` is that it is a built-in module of Python and
 therefore is ubiquitous and well-supported.
 `conda` is a more extensive package manager, which includes the ability to
-install and manage non-Python packages, like MKL or HDF5.
+install and manage non-Python dependencies, such as compilers or other
+libraries like MKL or HDF5.
 `conda` also doubles as an *environment manager*, allowing users to create and
 manage different *virtual environments* for their Python projects.
 

--- a/content/en/ecosystem/install.md
+++ b/content/en/ecosystem/install.md
@@ -50,3 +50,22 @@ and to circumvent the need to have administrator priviledges to install packages
 Pip accesses the Python Package Index, [PyPI](https://pypi.org/) which
 stores almost 200,000 projects, including all the packages of the scientific
 Python ecosystem.
+
+## Testing the installation
+
+An easy way to verify that the installation was successful is to `import` the
+installed packages in an interactive Python session.
+For example, open up an IPython terminal[^1] by typing `ipython` in the
+commande line.
+Once in the terminal session, try importing the packages you want to use like
+so:
+
+```python
+In [1]:  import numpy as np
+
+In [2]:  import matplotlib.pyplot as plt
+```
+
+You're now ready to start using the tools of the scientific Python ecosystem!
+
+[^1]: Note `ipython` was installed in the previous step.


### PR DESCRIPTION
Another pass over this transcript in an attempt to resolve some of the remaining ideas in #103.

The main thing is adding a "test your installation" section. This is related to the idea of moving the "hello scipy" to this video, but I actually agree with @stefanv 's suggestion in #104 that it'd be nice to keep+expand on the hello-scipy example in the "next steps" video instead. So instead I've proposed to add a section for testing the installation by opening an interpreter and attempting to import installed packages, which I think will flow nicely into the "next-steps" video.

In order to keep the length manageable, I cut out some of the other text - most notably the multiple options for installing `conda` (pared down to just miniconda) and some additional detail about PyPI and older versions.