### PR TITLE
add mpl calendar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(CALENDAR_DIR):
 $(CALENDAR_DIR)/%.ics: calendars/%.yaml $(CALENDAR_DIR)
 	python tools/yaml2ics/yaml2ics.py $< > $@
 
-calendars: $(CALENDAR_DIR)/numpy.ics $(CALENDAR_DIR)/scipy.ics
+calendars: $(CALENDAR_DIR)/numpy.ics $(CALENDAR_DIR)/scipy.ics $(CALENDAR_DIR)/matplotlib.ics
 
 
 TEAMS_DIR = static/teams

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ https://github.com/gohugoio/hugo/releases
 
 and place it somewhere on your path.
 
+You will also require the development version of
+[ics](https://github.com/ics-py/ics-py).
+
 ## Building the website
 
 For development, start the development server using

--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -1,0 +1,18 @@
+name: Matplotlib Community Calendar
+events:
+  - summary: Weekly Matplotlib Call
+    description: |
+      The Weekly Matplotlib call.
+
+      All are welcome.
+
+      Meeting notes: https://hackmd.io/@matplotlib
+
+    begin: 2022-03-10 20:00:00 +00:00
+    end: 2022-03-10 21:00:00 +00:00
+    url: https://zoom.us/j/384435716?pwd=WFpxVWxoYXArTDFzN1lWaHNoOE8xZz09
+    repeat:
+      interval:
+        # seconds, minutes, hours, days, weeks, months, years
+        days: 7
+      until: 2025-01-01 00:00:00 +00:00


### PR DESCRIPTION
Add the Matplotlib weekly call to the calenders.

I also updated the docs and the make file based on what I had to do to get the
website to build locally.

