### PR TITLE
Add forum to navbar

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ params:
       url: https://learn.scientific-python.org/contributors/
     - title: Maintainer Guide
       url: https://learn.scientific-python.org/maintainers/
-    - title: "\u2197 Discussion Forum"
+    - title: "Discussion Forum \u2197"
       url: https://discuss.scientific-python.org/
 
   hero:

--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ params:
       url: https://learn.scientific-python.org/contributors/
     - title: Maintainer Guide
       url: https://learn.scientific-python.org/maintainers/
-    - title: Discussion Forum
+    - title: "Discussion Forum\u29C9"
       url: https://discuss.scientific-python.org/
 
   hero:

--- a/config.yaml
+++ b/config.yaml
@@ -36,14 +36,16 @@ params:
   navbar:
     - title: Home
       url: /
+    - title: Blog
+      url: https://blog.scientific-python.org/
     - title: User Guide
       url: https://learn.scientific-python.org/users/
     - title: Contributor Guide
       url: https://learn.scientific-python.org/contributors/
     - title: Maintainer Guide
       url: https://learn.scientific-python.org/maintainers/
-    - title: Blog
-      url: https://blog.scientific-python.org/
+    - title: Discussion Forum
+      url: https://discuss.scientific-python.org/
 
   hero:
     # Main hero title

--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ params:
       url: https://learn.scientific-python.org/contributors/
     - title: Maintainer Guide
       url: https://learn.scientific-python.org/maintainers/
-    - title: "Discussion Forum\u2197"
+    - title: "\u2197 Discussion Forum"
       url: https://discuss.scientific-python.org/
 
   hero:

--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ params:
       url: https://learn.scientific-python.org/contributors/
     - title: Maintainer Guide
       url: https://learn.scientific-python.org/maintainers/
-    - title: "Discussion Forum\u29C9"
+    - title: "Discussion Forum\u2197"
       url: https://discuss.scientific-python.org/
 
   hero:


### PR DESCRIPTION
With just b773b1a
![screenshot](https://user-images.githubusercontent.com/123428/159407208-c434acb8-acdc-4a5c-858c-59deea55f76f.png)

with 3d6d9f3
![screenshot](https://user-images.githubusercontent.com/123428/159407495-e0de88cd-1625-4c8b-ad23-2e03c02c74bb.png)

with f102379
![screenshot](https://user-images.githubusercontent.com/123428/159409368-af458287-144e-4305-8f76-c22dbf5ac45c.png)

with 85b6763
![screenshot](https://user-images.githubusercontent.com/123428/159411898-47fb3456-ddce-4c2d-864c-b3918ec860b1.png)


@stefanv  I prefer the NW arrow over the two joined squares.

When we merge https://github.com/scientific-python/scientific-python-hugo-theme/pull/162, we can remove the unicode symbol.