### PR TITLE
Adding scikit-image community calendar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(CALENDAR_DIR):
 $(CALENDAR_DIR)/%.ics: calendars/%.yaml $(CALENDAR_DIR)
 	python tools/yaml2ics/yaml2ics.py $< > $@
 
-calendars: $(CALENDAR_DIR)/numpy.ics $(CALENDAR_DIR)/scipy.ics $(CALENDAR_DIR)/matplotlib.ics
+calendars: $(CALENDAR_DIR)/numpy.ics $(CALENDAR_DIR)/scipy.ics $(CALENDAR_DIR)/matplotlib.ics $(CALENDAR_DIR)/skimage.ics
 
 
 TEAMS_DIR = static/teams

--- a/calendars/skimage.yaml
+++ b/calendars/skimage.yaml
@@ -1,0 +1,16 @@
+name: scikit-image Community Calendar
+timezone: America/Los_Angeles
+events:
+  - summary: scikit-image Community Call (Americas/Oceania)
+    description: |
+      The scikit-image Community Call. Friendly for Americas/Oceania.
+
+      Meeting notes: https://hackmd.io/@alexdesiqueira/HyyHcIjQ9
+    begin: 2022-04-13 14:00:00 +00:00
+    end: 2022-04-13 15:00:00 +00:00
+    url: https://monash.zoom.us/j/86773951773?pwd=Njc4eThpckxvU2dFWW9VZ2NTRDFmdz09
+    repeat:
+      interval:
+        # seconds, minutes, hours, days, weeks, months, years
+        days: 14
+      until: 2025-01-01 00:00:00 +00:00


### PR DESCRIPTION
Adding the scikit-image Community Calendar. Americas/Oceania meeting scheduled so far.