### PR TITLE
Fixing typo: calender -> calendar

### DIFF
--- a/content/calendars/_index.md
+++ b/content/calendars/_index.md
@@ -2,4 +2,4 @@
 title: Community Calendars 📅
 ---
 
-Subscribe from any calender software that supports ICAL by either **copying** or **downloading** the following URLs:
+Subscribe from any calendar software that supports ICAL by either **copying** or **downloading** the following URLs:


### PR DESCRIPTION
Small typo on `scientific-python.org/calendars`.