### PR TITLE
Embed a calendar with all the events on the Calendar page

### DIFF
--- a/layouts/calendars/list.html
+++ b/layouts/calendars/list.html
@@ -37,15 +37,15 @@
         </div>
 
         <br>
-
+        <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
         <link href='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.0/main.min.css' rel='stylesheet' />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/ical.js/1.4.0/ical.min.js"></script>
         <script src='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.0/main.min.js'></script>
         <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@5.11.0/main.global.min.js"></script>
-        <script>
 
+        <script>
           document.addEventListener('DOMContentLoaded', function() {
-            var cal_colors = ["red", "blue", "green", "grey", "purple"];
+            var cal_colors = vega.scheme('category10');
             var community_calendar = document.getElementById('community_calendar');
             var calendar = new FullCalendar.Calendar(community_calendar, {
                 timeZone: 'local',
@@ -60,7 +60,7 @@
                     {
                         url: '{{ $key }}.ics',
                         format: 'ics',
-                        backgroundColor: cal_colors.pop(),
+                        backgroundColor: cal_colors.shift(),
                     },
                 {{ end }}
                 ],

--- a/layouts/calendars/list.html
+++ b/layouts/calendars/list.html
@@ -36,6 +36,39 @@
           {{ end }}
         </div>
 
+        <br>
+
+        <link href='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.0/main.min.css' rel='stylesheet' />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ical.js/1.4.0/ical.min.js"></script>
+        <script src='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.0/main.min.js'></script>
+        <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@5.11.0/main.global.min.js"></script>
+        <script>
+
+          document.addEventListener('DOMContentLoaded', function() {
+            var community_calendar = document.getElementById('community_calendar');
+            var calendar = new FullCalendar.Calendar(community_calendar, {
+                timeZone: 'local',
+                initialView: 'dayGridMonth',
+                headerToolbar: {
+                  left: "prev,next today",
+                  center: "title",
+                  right: "dayGridMonth,timeGridWeek,timeGridDay",
+                },
+                eventSources: [
+                {{ range $key, $value := $.Site.Data.calendars }}
+                    {
+                        url: '{{ $key }}.ics',
+                        format: 'ics'
+                    },
+                {{ end }}
+                ],
+            });
+            calendar.render();
+          });
+
+        </script>
+        <div id='community_calendar'></div>
+
         <h3 id="subscribe-google-calendar">Google Calendar</h3>
         Instructions from <a href="https://support.google.com/calendar/answer/37100?hl=en&co=GENIE.Platform%3DDesktop">the Google Calendar docs</a>:
         <ol>

--- a/layouts/calendars/list.html
+++ b/layouts/calendars/list.html
@@ -48,19 +48,20 @@
             var cal_colors = vega.scheme('category10');
             var community_calendar = document.getElementById('community_calendar');
             var calendar = new FullCalendar.Calendar(community_calendar, {
+                aspectRatio: 1,
                 timeZone: 'local',
                 initialView: 'dayGridMonth',
                 headerToolbar: {
                   left: "prev,next today",
                   center: "title",
-                  right: "dayGridMonth,timeGridWeek,timeGridDay",
+                  right: "dayGridMonth,timeGridWeek,listWeek",
                 },
                 eventSources: [
                 {{ range $key, $value := $.Site.Data.calendars }}
                     {
                         url: '{{ $key }}.ics',
                         format: 'ics',
-                        backgroundColor: cal_colors.shift(),
+                        color: cal_colors.shift(),
                     },
                 {{ end }}
                 ],

--- a/layouts/calendars/list.html
+++ b/layouts/calendars/list.html
@@ -62,6 +62,10 @@
                     },
                 {{ end }}
                 ],
+                eventClick: function(info) {
+                    info.jsEvent.preventDefault();
+                    alert('Event: ' + info.event.title + '\n' + info.event.extendedProps.description + '\n' + 'URL: ' +info.event.url);
+                }
             });
             calendar.render();
           });

--- a/layouts/calendars/list.html
+++ b/layouts/calendars/list.html
@@ -45,6 +45,7 @@
         <script>
 
           document.addEventListener('DOMContentLoaded', function() {
+            var cal_colors = ["red", "blue", "green", "grey", "purple"];
             var community_calendar = document.getElementById('community_calendar');
             var calendar = new FullCalendar.Calendar(community_calendar, {
                 timeZone: 'local',
@@ -58,14 +59,16 @@
                 {{ range $key, $value := $.Site.Data.calendars }}
                     {
                         url: '{{ $key }}.ics',
-                        format: 'ics'
+                        format: 'ics',
+                        backgroundColor: cal_colors.pop(),
                     },
                 {{ end }}
                 ],
                 eventClick: function(info) {
                     info.jsEvent.preventDefault();
                     alert('Event: ' + info.event.title + '\n' + info.event.extendedProps.description + '\n' + 'URL: ' +info.event.url);
-                }
+                },
+                eventDisplay: 'block',
             });
             calendar.render();
           });


### PR DESCRIPTION
If someone opens up the Calendar page they will see a bunch of download link for .ics file but they wouldn't really know what kind of "commitment" they are looking at. This embeds a calendar on the page using the `fullcalendar` package. Everything is loaded via a CDN so no need to compile anything.