### PR TITLE
Moved SciPy meetings one week forward

### DIFF
--- a/calendars/scipy.yaml
+++ b/calendars/scipy.yaml
@@ -5,8 +5,8 @@ events:
       This is the Europe/Asia-friendly meeting.
 
       Meeting notes: https://hackmd.io/pyhudrC5TgSwdJtpPldHgQ
-    begin: 2022-02-02 12:00:00 +00:00
-    end: 2022-02-02 13:00:00 +00:00
+    begin: 2022-07-27 12:00:00 +00:00
+    end: 2022-07-27 13:00:00 +00:00
     url: https://us06web.zoom.us/j/6345425936
     repeat:
       interval:
@@ -19,8 +19,8 @@ events:
       This is the Americas-friendly meeting.
 
       Meeting notes: https://hackmd.io/pyhudrC5TgSwdJtpPldHgQ
-    begin: 2022-02-16 20:00:00 +00:00
-    end: 2022-02-16 21:00:00 +00:00
+    begin: 2022-07-13 20:00:00 +00:00
+    end: 2022-07-13 21:00:00 +00:00
     url: https://us06web.zoom.us/j/6345425936
     repeat:
       interval:


### PR DESCRIPTION
Hello folks,

This PR moves the SciPy community meetings forward one week to avoid conflicts with the NumPy community meetings.

cc @tupui 