### PR TITLE
Update NX and skimage calendars to use UTC time.

### DIFF
--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -1,5 +1,4 @@
 name: NetworkX Community Calendar
-timezone: America/Los_Angeles
 events:
   - summary: NetworkX Community Call (Americas/Oceania)
     description: |

--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -7,8 +7,8 @@ events:
 
       Meeting Link:  https://colgate.zoom.us/j/92619161786
       Meeting notes: https://hackmd.io/ea2IhUuqSrG4kM9tokXuEw
-    begin: 2022-06-09 10:00:00
-    end: 2022-06-09 11:00:00
+    begin: 2022-06-09 17:00:00 +00:00
+    end: 2022-06-09 18:00:00 +00:00
     url: https://colgate.zoom.us/j/92619161786
     repeat:
       interval:

--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -12,4 +12,4 @@ events:
     repeat:
       interval:
         days: 7
-      until: 2025-08-26 00:00:00
+      until: 2025-08-26 00:00:00 +00:00

--- a/calendars/skimage.yaml
+++ b/calendars/skimage.yaml
@@ -6,8 +6,8 @@ events:
       The scikit-image Community Call. Timezone-friendly for Europe/Africa.
 
       Meeting notes: https://hackmd.io/@alexdesiqueira/skimage_cc
-    begin: 2022-06-14 10:00:00
-    end: 2022-06-14 11:00:00
+    begin: 2022-06-14 17:00:00 +00:00
+    end: 2022-06-14 18:00:00 +00:00
     url: https://berkeley.zoom.us/j/4760246500?pwd=dC9jVVB0ZzlHT0VpdlBkc21oYmVUQT09
     repeat:
       interval:
@@ -18,8 +18,8 @@ events:
       The scikit-image Community Call. Timezone-friendly for Americas/Oceania.
 
       Meeting notes: https://hackmd.io/@alexdesiqueira/skimage_cc
-    begin: 2022-06-21 15:00:00
-    end: 2022-06-21 16:00:00
+    begin: 2022-06-21 22:00:00 +00:00
+    end: 2022-06-21 23:00:00 +00:00
     url: https://berkeley.zoom.us/j/4760246500?pwd=dC9jVVB0ZzlHT0VpdlBkc21oYmVUQT09
     repeat:
       interval:

--- a/calendars/skimage.yaml
+++ b/calendars/skimage.yaml
@@ -1,5 +1,4 @@
 name: scikit-image Community Calendar
-timezone: America/Los_Angeles
 events:
   - summary: scikit-image Community Call (Europe/Africa)
     description: |

--- a/calendars/skimage.yaml
+++ b/calendars/skimage.yaml
@@ -11,7 +11,7 @@ events:
     repeat:
       interval:
         days: 14
-      until: 2025-01-01 00:00:00
+      until: 2025-01-01 00:00:00 +00:00
   - summary: scikit-image Community Call (Americas/Oceania)
     description: |
       The scikit-image Community Call. Timezone-friendly for Americas/Oceania.
@@ -23,4 +23,4 @@ events:
     repeat:
       interval:
         days: 14
-      until: 2025-01-01 00:00:00
+      until: 2025-01-01 00:00:00 +00:00


### PR DESCRIPTION
The [newly-added calendar widget (scroll to bottom of page)](https://scientific-python.org/calendars/) is showing the scikit-image and networkx meetings at incorrect times. AFAICT, the times are shown at the defined times (e.g. 10 AM for the NX meeting) regardless of timezone.

In an attempt to fix this, I switched the meeting definitions to UTC time and added the `+00:00` to indicate the timezone. This matches the pattern used for e.g. the numpy and scipy meetings, which show up at the correct times in my current timezone in the calendar widget.