### PR TITLE
Fix timezone for SciPy newcomers meetings

### DIFF
--- a/calendars/scipy.yaml
+++ b/calendars/scipy.yaml
@@ -36,8 +36,8 @@ events:
 
       Meeting notes: https://hackmd.io/@melissawm/H15ahr5wq
 
-    begin: 2022-05-27 19:00:00
-    end: 2022-05-27 20:00:00
+    begin: 2022-05-27 19:00:00 +00:00
+    end: 2022-05-27 20:00:00 +00:00
     url: https://us06web.zoom.us/j/6345425936?pwd=aDVFQzVmbk9SVU5jU0Jwc0s3YWUrdz09
     repeat:
       interval:


### PR DESCRIPTION
Hi folks,

The newcomers meetings for SciPy are showing up with the wrong time in our calendar, probably because there is no explicit timezone selected. This PR should fix it. Thanks!