### PR TITLE
Use lighthouse 3.0.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,15 +4,3 @@
 
 [[plugins]]
   package = "netlify-plugin-checklinks"
-
-# optional, fails build when a category is below a threshold
-[plugins.inputs.thresholds]
-  performance = 0.75
-  accessibility = 0.95
-  best-practices = 0.95
-  seo = 0.95
-  pwa = 0.2
-
-# optional, deploy the lighthouse report to a path under your site
-[plugins.inputs]
-  output_path = "reports/lighthouse.html"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,17 +5,14 @@
 [[plugins]]
   package = "netlify-plugin-checklinks"
 
-[[plugins]]
-  package = "@netlify/plugin-lighthouse"
+# optional, fails build when a category is below a threshold
+[plugins.inputs.thresholds]
+  performance = 0.75
+  accessibility = 0.95
+  best-practices = 0.95
+  seo = 0.95
+  pwa = 0.2
 
-  # optional, fails build when a category is below a threshold
-  [plugins.inputs.thresholds]
-    performance = 0.75
-    accessibility = 0.95
-    best-practices = 0.95
-    seo = 0.95
-    pwa = 0.2
-
-  # optional, deploy the lighthouse report to a path under your site
-  [plugins.inputs]
-    output_path = "reports/lighthouse.html"
+# optional, deploy the lighthouse report to a path under your site
+[plugins.inputs]
+  output_path = "reports/lighthouse.html"


### PR DESCRIPTION
Not sure, but I am trying to follow this message from the netlify deploy logs:
```
12:32:35 PM: ❯ Installing plugins
12:32:35 PM:    - @netlify/plugin-lighthouse@2.1.3
12:32:35 PM:    - netlify-plugin-checklinks@4.1.1
12:33:13 PM: ​
12:33:13 PM: ❯ Loading plugins
12:33:13 PM:    - @netlify/plugin-lighthouse@2.1.3 from netlify.toml
12:33:13 PM:    - netlify-plugin-checklinks@4.1.1 from netlify.toml
12:33:13 PM: ​
12:33:13 PM: ❯ Outdated plugins
12:33:13 PM:    - @netlify/plugin-lighthouse@2.1.3: latest version is 3.0.1
12:33:13 PM:      To upgrade this plugin, please remove it from "netlify.toml" and install it from the Netlify plugins directory instead (https://app.netlify.com/plugins)
```