### PR TITLE
Add community landing page in scientific python website

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,9 +44,8 @@ params:
     #  url: https://learn.scientific-python.org/contributors/
     #- title: Maintainer Guide
     #  url: https://learn.scientific-python.org/maintainers/
-    - title: Discussion Forum
-      url: https://discuss.scientific-python.org/
-      is_external: true
+    - title: Community
+      url: /community/
 
   hero:
     # Main hero title

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Community"
+---
+
+The Scientific Python community is the group of developers, maintainers, and users of tools in the Scientific Python ecosystem. We are dedicated to expanding our community in a welcoming and inclusive way so all community members must adhere to our [code of conduct](https://scientific-python.org/code_of_conduct/).
+
+![community picture](images/community.png)
+
+If you want to learn more about the Scientific Python community, visit our [Community Guide](https://learn.scientific-python.org/community/).
+
+## Join the community
+
+There are many ways to get involved in the Scientific Python community:
+
+### Discussion forum
+
+You can Join the Scientific Python [Discussion Forum](https://discuss.scientific-python.org) where you can be part of ongoing conversations about the Scientific Python ecosystem.
+
+
+### Discord server
+
+You can join the discussion on our [Discord server](https://discord.gg/vur45CbwMz) for synchronous communication with members of our community.
+

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -16,8 +16,6 @@ There are many ways to get involved in the Scientific Python community:
 
 You can Join the Scientific Python [Discussion Forum](https://discuss.scientific-python.org) where you can be part of ongoing conversations about the Scientific Python ecosystem.
 
-
 ### Discord server
 
 You can join the discussion on our [Discord server](https://discord.gg/vur45CbwMz) for synchronous communication with members of our community.
-


### PR DESCRIPTION
After a discussion on Friday with @tupui and @jarrodmillman we agreed that we needed a community page in the Scientific Python website so I did this initial PR to add it replacing the Discussion forum link. 

I added some basic information including the links to our community guide and the communication channels.

Please let me know what other information you think should go here and I can continue working on it. 