### PR TITLE
Change SciPy newcomers meeting time and zoom link

### DIFF
--- a/calendars/scipy.yaml
+++ b/calendars/scipy.yaml
@@ -36,9 +36,9 @@ events:
 
       Meeting notes: https://hackmd.io/@melissawm/H15ahr5wq
 
-    begin: 2022-05-27 19:00:00 +00:00
-    end: 2022-05-27 20:00:00 +00:00
-    url: https://us06web.zoom.us/j/6345425936?pwd=aDVFQzVmbk9SVU5jU0Jwc0s3YWUrdz09
+    begin: 2022-08-19 12:00:00 +00:00
+    end: 2022-08-19 13:00:00 +00:00
+    url: https://us06web.zoom.us/j/89085469494?pwd=dVFwK3dVczRyRUowZWZkckFtTmloUT09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years


### PR DESCRIPTION
To experiment and see what times are more popular, I am changing this meeting time to be earlier and more Europe/Asia-friendly this time. 

I also changed the zoom link as the meeting now includes a short anonymous survey to be lauched at the end with feedback from participants. 

cc @tupui 