### PR TITLE
Update skimage comm call's frequency, add address

### DIFF
--- a/calendars/skimage.yaml
+++ b/calendars/skimage.yaml
@@ -6,12 +6,12 @@ events:
 
       Meeting notes: https://hackmd.io/@alexdesiqueira/skimage_cc
       Archive — Meeting Notes: https://github.com/scikit-image/meeting-notes
-    begin: 2022-06-14 17:00:00 +00:00
-    end: 2022-06-14 18:00:00 +00:00
-    url: https://meet.google.com/icq-geqg-yix
+    begin: 2022-08-23 17:00:00 +00:00
+    end: 2022-08-23 18:00:00 +00:00
+    url: https://us06web.zoom.us/j/88060567580?pwd=THRpaWFnSFNwK0Fycy9FVk5RYnV5UT09
     repeat:
       interval:
-        days: 14
+        days: 28
       until: 2025-01-01 00:00:00 +00:00
   - summary: scikit-image Community Call (Americas/Oceania)
     description: |
@@ -21,8 +21,8 @@ events:
       Archive — Meeting Notes: https://github.com/scikit-image/meeting-notes
     begin: 2022-06-21 22:00:00 +00:00
     end: 2022-06-21 23:00:00 +00:00
-    url: https://meet.google.com/icq-geqg-yix
+    url: https://us06web.zoom.us/j/89135215899?pwd=ck8xRGg1SVNEWmlGMjlSd1BiOVZtZz09
     repeat:
       interval:
-        days: 14
+        days: 28
       until: 2025-01-01 00:00:00 +00:00

--- a/calendars/skimage.yaml
+++ b/calendars/skimage.yaml
@@ -19,8 +19,8 @@ events:
 
       Meeting notes: https://hackmd.io/@alexdesiqueira/skimage_cc
       Archive — Meeting Notes: https://github.com/scikit-image/meeting-notes
-    begin: 2022-06-21 22:00:00 +00:00
-    end: 2022-06-21 23:00:00 +00:00
+    begin: 2022-09-06 22:00:00 +00:00
+    end: 2022-09-06 23:00:00 +00:00
     url: https://us06web.zoom.us/j/89135215899?pwd=ck8xRGg1SVNEWmlGMjlSd1BiOVZtZz09
     repeat:
       interval:


### PR DESCRIPTION
Updating scikit-image community call's frequency — biweekly, instead of weekly — and adding a more permanent address for the calls.