### PR TITLE
Improve the name of the Matplotlib weekly meeting

### DIFF
--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -18,7 +18,7 @@ events:
         days: 7
       until: 2025-01-01 00:00:00
 
-  - summary: Monthly Matplotlib New Contributor Meeting
+  - summary: Matplotlib Monthly New Contributor Meeting
     description: |
       The monthly call for new contributors to the Matplotlib project 🎉
 

--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -1,13 +1,13 @@
 name: Matplotlib Community Calendar
 timezone: Europe/Berlin
 events:
-  - summary: Plot Plotting (weekly open projet call)
+  - summary: Matplotlib — Plot Plotting (open project call)
     description: |
-      The Weekly Matplotlib call.
+      The Weekly Matplotlib project call.
 
       All are welcome.
 
-      Meeting notes: https://hackmd.io/@matplotlib
+      Meeting notes and agenda: https://hackmd.io/@matplotlib
 
     begin: 2022-03-24 21:00:00
     end: 2022-03-24 22:00:00

--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -1,7 +1,7 @@
 name: Matplotlib Community Calendar
 timezone: Europe/Berlin
 events:
-  - summary: Weekly Matplotlib Call
+  - summary: Plot Plotting (weekly open projet call)
     description: |
       The Weekly Matplotlib call.
 


### PR DESCRIPTION
If this is either too long or not clear enough I can move "plot plotting" in to the description.