### PR TITLE
Remove next Monday's numpy docs meeting from the calendar.

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -41,8 +41,8 @@ events:
 
       To add to the meeting agenda the topics you'd like to discuss,
       follow the link: https://hackmd.io/oB_boakvRqKR-_2jRV-Qjg
-    begin: 2022-07-18 14:00:00 +00:00
-    end: 2022-07-18 15:00:00 +00:00
+    begin: 2022-10-10 14:00:00 +00:00
+    end: 2022-10-10 15:00:00 +00:00
     url: https://us06web.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
     repeat:
       interval:


### PR DESCRIPTION
The 9/26 meeting is cancelled due to limited availability.