### PR TITLE
Updates to sparse summit meeting 1 page

### DIFF
--- a/content/summits/sparse/meeting1.md
+++ b/content/summits/sparse/meeting1.md
@@ -32,12 +32,16 @@ birds-of-a-feather (BoF)-style talks, followed by more focused discussion.
 
 2. (20 min) BoF Presentations (4 min each)
 
-   - Dan Schult: [Proposal for array semantics in `scipy.sparse`](https://scientific-python.org/doc/sparse-arrays-grant-2022.pdf)
-   - Hameer Abbasi: [PyData/Sparse -- Future Plans](https://raw.githubusercontent.com/scientific-python/scientific-python.org-blobs/main/summits/sparse/meeting1/hameer-abbasi.pdf)
+   - Dan Schult: Proposal for array semantics in `scipy.sparse` [(download)][scipy]
+   - Hameer Abbasi: PyData/Sparse -- Future Plans [(download)][pydata-sparse]
    - Jim Kitchen: needs/roles of sparse in GraphBLAS
    - Isaac Virshup: needs/roles of sparse in scverse
-   - Julien Jerphanion: [Usage and needs for sparse data in `scikit-learn`](https://raw.githubusercontent.com/scientific-python/scientific-python.org-blobs/main/summits/sparse/meeting1/julien-jerphanion.pdf)
+   - Julien Jerphanion: Usage and needs for sparse data in `scikit-learn` [(download)][sklearn]
 
 3. (30 min) Discussion
 
 4. (5 min) Wrap up and next steps
+
+[scipy]: https://scientific-python.org/doc/sparse-arrays-grant-2022.pdf
+[pydata-sparse]: https://raw.githubusercontent.com/scientific-python/scientific-python.org-blobs/main/summits/sparse/meeting1/hameer-abbasi.pdf
+[sklearn]: https://raw.githubusercontent.com/scientific-python/scientific-python.org-blobs/main/summits/sparse/meeting1/julien-jerphanion.pdf

--- a/content/summits/sparse/meeting1.md
+++ b/content/summits/sparse/meeting1.md
@@ -10,7 +10,10 @@ title: "Meeting 1"
 ## Participants
 
 - Hameer Abbasi
+- Nezar Abdennur
 - Ross Barnowski
+- CJ Carey
+- Jérémie du Boisberranger
 - Julien Jerphanion
 - Jim Kitchen
 - Jarrod Millman
@@ -18,6 +21,7 @@ title: "Meeting 1"
 - Stéfan van der Walt
 - Isaac Virshup
 - Erik Welch
+- Meekail Zain
 
 ## Agenda
 

--- a/content/summits/sparse/meeting1.md
+++ b/content/summits/sparse/meeting1.md
@@ -6,7 +6,6 @@ title: "Meeting 1"
 
 - Date: Monday, [September 26th 11AM - 12PM Pacific time (click for your timezone)](https://www.timeanddate.com/worldclock/converter.html?iso=20220926T180000&p1=224)
 - Zoom Link (sign in required): https://berkeley.zoom.us/j/96628687450?pwd=Q29oeDc5NnJEYlFHVU1yVUFITzNQUT09
-- Meeting Notes: https://hackmd.io/gaL-4PhRQR6jAGUZ0QF3BQ
 
 ## Participants
 


### PR DESCRIPTION
Some post-summit updates:
 - Remove the link to the live hackmd (to be replaced with static version of notes once archiving is figured out)
 - Update list of participants to reflect attendees
 - Tweak links to presentations to make clear that they are downloading pdfs