### PR TITLE
Update info about NumPy Newcomers’ Hours

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -65,7 +65,7 @@ events:
         days: 28
       until: 2025-01-01 00:00:00 +00:00
       
-      - summary: NumPy Newcomers' Hour
+  - summary: NumPy Newcomers' Hour
     description: |
       A fortnightly meeting for newcomers to the NumPy contributor community.
 

--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -64,7 +64,7 @@ events:
         # seconds, minutes, hours, days, weeks, months, years
         days: 28
       until: 2025-01-01 00:00:00 +00:00
-      
+
   - summary: NumPy Newcomers' Hour
     description: |
       A fortnightly meeting for newcomers to the NumPy contributor community.

--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -56,11 +56,26 @@ events:
 
       To add to the meeting agenda the topics you’d like to discuss,
       follow the link: https://hackmd.io/3f3otyyuTte3FU9y3QzsLg
-    begin: 2022-02-10 14:00:00 +00:00
-    end: 2022-02-10 15:00:00 +00:00
+    begin: 2022-11-03 12:00:00 +00:00
+    end: 2022-11-03 13:00:00 +00:00
     url: https://us06web.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years
-        days: 14
+        days: 28
+      until: 2025-01-01 00:00:00 +00:00
+      
+      - summary: NumPy Newcomers' Hour
+    description: |
+      A fortnightly meeting for newcomers to the NumPy contributor community.
+
+      To add to the meeting agenda the topics you’d like to discuss,
+      follow the link: https://hackmd.io/3f3otyyuTte3FU9y3QzsLg
+    begin: 2022-10-20 20:00:00 +00:00
+    end: 2022-10-20 21:00:00 +00:00
+    url: https://us06web.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
+    repeat:
+      interval:
+        # seconds, minutes, hours, days, weeks, months, years
+        days: 28
       until: 2025-01-01 00:00:00 +00:00


### PR DESCRIPTION
To better accommodate our contributors from every part of the world, we are introducing rotating schedule for NumPy Newcomers’ Hours. The new start times are 12:00 UTC and 20:00 UTC which will be alternating on a bi-weekly basis. This pull request will update the NumPy community calendar to reflect these changes.