### PR TITLE
Moved monthly meeting to first week of the month

### DIFF
--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -31,4 +31,3 @@ events:
     url: https://us06web.zoom.us/j/81285851006?pwd=Tks2QjRkNWh5NGw0TmU1RUwwOVluZz09
     ics: |
       RRULE:FREQ=MONTHLY;BYDAY=1WE
-      

--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -29,5 +29,4 @@ events:
     begin: 2022-12-06 19:00:00
     end: 2022-12-06 20:00:00
     url: https://us06web.zoom.us/j/81285851006?pwd=Tks2QjRkNWh5NGw0TmU1RUwwOVluZz09
-    ics: |
-      RRULE:FREQ=MONTHLY;BYDAY=1WE
+    ics: RRULE:FREQ=MONTHLY;BYDAY=1WE

--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -18,7 +18,7 @@ events:
         days: 7
       until: 2025-01-01 00:00:00
 
-  - summary: Matplotlib Monthly New Contributor Meeting
+  - summary: Matplotlib Monthly New Contributors Meeting
     description: |
       The monthly call for new contributors to the Matplotlib project 🎉
 
@@ -26,8 +26,8 @@ events:
 
       Meeting notes: https://hackmd.io/@matplotlib
 
-    begin: 2022-09-06 19:00:00
-    end: 2022-09-06 20:00:00
+    begin: 2022-12-06 19:00:00
+    end: 2022-12-06 20:00:00
     url: https://us06web.zoom.us/j/81285851006?pwd=Tks2QjRkNWh5NGw0TmU1RUwwOVluZz09
     repeat:
       interval:

--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -29,8 +29,5 @@ events:
     begin: 2022-12-06 19:00:00
     end: 2022-12-06 20:00:00
     url: https://us06web.zoom.us/j/81285851006?pwd=Tks2QjRkNWh5NGw0TmU1RUwwOVluZz09
-    repeat:
-      interval:
-        # seconds, minutes, hours, days, weeks, months, years
-        days: 28
-      until: 2025-01-01 00:00:00
+    ics: |
+      RRULE:FREQ=MONTHLY;BYDAY=1WE

--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -31,3 +31,4 @@ events:
     url: https://us06web.zoom.us/j/81285851006?pwd=Tks2QjRkNWh5NGw0TmU1RUwwOVluZz09
     ics: |
       RRULE:FREQ=MONTHLY;BYDAY=1WE
+      

--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -29,4 +29,4 @@ events:
     begin: 2022-12-06 19:00:00
     end: 2022-12-06 20:00:00
     url: https://us06web.zoom.us/j/81285851006?pwd=Tks2QjRkNWh5NGw0TmU1RUwwOVluZz09
-    ics: RRULE:FREQ=MONTHLY;BYDAY=1WE
+    ics: RRULE:FREQ=MONTHLY;BYDAY=1TU


### PR DESCRIPTION
@tupui I may have asked this before. But is it possible to set a meeting to be on the first week of the month rather than on a 4 week interval to avoid this sliding effect? It would reduce maintenance on the calendar for monthly meetings ☺️