### PR TITLE
Update NumPy docs meeting times

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -33,7 +33,7 @@ events:
         days: 14
       until: 2025-01-01 00:00:00 +00:00
 
-  - summary: NumPy Documentation Team meeting
+  - summary: NumPy Documentation Team meeting (Europe/Africa/Asia)
     description: |
       A fortnightly meeting to discuss everything related
       to the official NumPy documentation. Everyone is welcome to attend
@@ -41,13 +41,30 @@ events:
 
       To add to the meeting agenda the topics you'd like to discuss,
       follow the link: https://hackmd.io/oB_boakvRqKR-_2jRV-Qjg
-    begin: 2022-10-10 14:00:00 +00:00
-    end: 2022-10-10 15:00:00 +00:00
+    begin: 2022-11-07 12:00:00 +00:00
+    end: 2022-11-07 13:00:00 +00:00
     url: https://us06web.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years
-        days: 14
+        days: 28
+      until: 2025-01-01 00:00:00 +00:00
+
+  - summary: NumPy Documentation Team meeting (Americas/Oceania)
+    description: |
+      A fortnightly meeting to discuss everything related
+      to the official NumPy documentation. Everyone is welcome to attend
+      and contribute to a conversation.
+
+      To add to the meeting agenda the topics you'd like to discuss,
+      follow the link: https://hackmd.io/oB_boakvRqKR-_2jRV-Qjg
+    begin: 2022-11-21 16:00:00 +00:00
+    end: 2022-11-21 17:00:00 +00:00
+    url: https://us06web.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
+    repeat:
+      interval:
+        # seconds, minutes, hours, days, weeks, months, years
+        days: 28
       until: 2025-01-01 00:00:00 +00:00
 
   - summary: NumPy Newcomers' Hour (Europe/Africa/Asia)


### PR DESCRIPTION
Create alternating meeting times to reach more timezones.

This monday's meeting will already be in the new time.