### PR TITLE
Update the time of NumPy community calls

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -8,8 +8,8 @@ events:
 
       To add to the meeting agenda the topics you’d like to discuss,
       follow the link: https://hackmd.io/76o-IxCjQX2mOXO_wwkcpg
-    begin: 2022-01-19 18:00:00 +00:00
-    end: 2022-01-19 19:00:00 +00:00
+    begin: 2022-11-23 19:00:00 +00:00
+    end: 2022-11-23 20:00:00 +00:00
     url: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
     repeat:
       interval:


### PR DESCRIPTION
Due to the Daylight Saving Time shift, we had to revise the schedule of NumPy community calls to better accommodate our contributor community members schedules.