### PR TITLE
Update the Contributor Experience Project community calendar

### DIFF
--- a/calendars/contributor-experience.yaml
+++ b/calendars/contributor-experience.yaml
@@ -3,8 +3,8 @@ events:
   - summary: Contributor Experience Project Community Call (Africa/Asia/Europe/Oceania)
     description: |
       A bi-weekly meeting to discuss everything related to contributor experience. Everyone is welcome to attend and contribute to a conversation.
-    begin: 2022-10-31 09:00:00 +00:00
-    end: 2022-10-31 10:00:00 +00:00
+    begin: 2022-11-28 09:00:00 +00:00
+    end: 2022-11-28 10:00:00 +00:00
     url: https://us06web.zoom.us/j/88984371636?pwd=aTI1a1JZZUd6Wm93LzRrNVVjSHRhZz09
     repeat:
       interval:


### PR DESCRIPTION
The Nov 21st meeting has been canceled. The next Monday meeting is scheduled for Nov 28th.