### PR TITLE
Update the NumPy community events calendar

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -17,15 +17,15 @@ events:
         days: 14
       until: 2025-01-01 00:00:00 +00:00
 
-  - summary: NumPy Triage Call
+  - summary: NumPy Triage Call - CANCELED
     description: |
       A fortnightly meeting to synchronously triage prioritized PRs and issues.
       Everyone is welcome to attend and contribute to a conversation.
 
       Please notify us of an issue or PR that you’d like to have triaged/reviewed by adding
       a GitHub link to it in the meeting agenda: https://hackmd.io/68i_JvOYQfy9ERiHgXMPvg
-    begin: 2022-03-23 16:00:00 +00:00
-    end: 2022-03-23 17:00:00 +00:00
+    begin: 2022-12-28 16:00:00 +00:00
+    end: 2022-12-28 17:00:00 +00:00
     url: https://us06web.zoom.us/j/82096749952?pwd=MW9oUmtKQ1c3a2gydGk1RTdYUUVXZz09
     repeat:
       interval:
@@ -67,14 +67,14 @@ events:
         days: 28
       until: 2025-01-01 00:00:00 +00:00
 
-  - summary: NumPy Newcomers' Hour (Europe/Africa/Asia)
+  - summary: NumPy Newcomers' Hour (Europe/Africa/Asia) - CANCELED
     description: |
       A fortnightly meeting for newcomers to the NumPy contributor community.
 
       To add to the meeting agenda the topics you’d like to discuss,
       follow the link: https://hackmd.io/3f3otyyuTte3FU9y3QzsLg
-    begin: 2022-11-03 12:00:00 +00:00
-    end: 2022-11-03 13:00:00 +00:00
+    begin: 2022-12-29 12:00:00 +00:00
+    end: 2022-12-29 13:00:00 +00:00
     url: https://us06web.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
     repeat:
       interval:


### PR DESCRIPTION
Updating the NumPy calendar as there will be no community events hosted in the week of Dec 26th.