### PR TITLE
Update NX meeting time for early 2023.

### DIFF
--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -7,8 +7,8 @@ events:
 
       Meeting Link:  https://colgate.zoom.us/j/92619161786
       Meeting notes: https://hackmd.io/ea2IhUuqSrG4kM9tokXuEw
-    begin: 2022-09-13 10:00:00
-    end: 2022-09-13 11:00:00
+    begin: 2023-01-10 09:30:00
+    end: 2023-01-10 10:30:00
     url: https://colgate.zoom.us/j/92619161786
     repeat:
       interval:


### PR DESCRIPTION
See also: the [scheduling poll results](https://crab.fit/networkx-weekly-meetings-for-2023-767259)