### PR TITLE
update ossx calendar

### DIFF
--- a/calendars/contributor-experience.yaml
+++ b/calendars/contributor-experience.yaml
@@ -1,18 +1,8 @@
 name: Contributor Experience Project Community Calendar
 events:
-  - summary: Contributor Experience Project Community Call (Africa/Asia/Europe/Oceania)
+  - summary: Contributor Experience Project Community Call
     description: |
-      A bi-weekly meeting to discuss everything related to contributor experience. Everyone is welcome to attend and contribute to a conversation.
-    begin: 2022-11-28 09:00:00 +00:00
-    end: 2022-11-28 10:00:00 +00:00
-    url: https://us06web.zoom.us/j/88984371636?pwd=aTI1a1JZZUd6Wm93LzRrNVVjSHRhZz09
-    repeat:
-      interval:
-        days: 7
-      until: 2025-01-01 00:00:00 +00:00
-  - summary: Contributor Experience Project Community Call (Americas)
-    description: |
-      A bi-weekly meeting to discuss everything related to contributor experience. Everyone is welcome to attend and contribute to a conversation.
+      A weekly meeting to discuss everything related to contributor experience. Everyone is welcome to attend and contribute to a conversation. On Zoom: https://numfocus-org.zoom.us/j/81082067424?pwd=bVNqWXhqSXZEdTl6ZzFsa1lJZ08xZz09
     begin: 2022-11-11 15:00:00 +00:00
     end: 2022-11-11 16:00:00 +00:00
     url: https://numfocus-org.zoom.us/j/81082067424?pwd=bVNqWXhqSXZEdTl6ZzFsa1lJZ08xZz09


### PR DESCRIPTION
Change to one weekly meeting and adds the url in the description so folks using google calendar can see it.
CC @InessaPawson @melissawm 