### PR TITLE
Use default Python of netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  PYTHON_VERSION = "3.10"
+  PYTHON_VERSION = "3.8" # netlify currently only support 2.7 and 3.8
   HUGO_VERSION = "0.111.3"
 
 [[plugins]]


### PR DESCRIPTION
See https://docs.netlify.com/configure-builds/available-software-at-build-time/

```
Python

    Set the version using build environment variable PYTHON_VERSION or a runtime.txt or Pipfile file.
    3.8 (Default)
    2.7
```