### PR TITLE
Align NumPy community and triage meeting times

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -8,8 +8,8 @@ events:
 
       To add to the meeting agenda the topics you’d like to discuss,
       follow the link: https://hackmd.io/76o-IxCjQX2mOXO_wwkcpg
-    begin: 2022-11-23 19:00:00 +00:00
-    end: 2022-11-23 20:00:00 +00:00
+    begin: 2022-11-23 17:00:00 +00:00
+    end: 2022-11-23 18:00:00 +00:00
     url: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
     repeat:
       interval:

--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -1,10 +1,5 @@
 name: NumPy Community Calendar
 events:
-  - summary: NumPy 2.0 development meeting
-    begin: 2023-04-03 15:00:00 +00:00
-    end: 2023-04-03 19:00:00 +00:00
-    url: https://numfocus-org.zoom.us/j/87080449579?pwd=dmt5dktCT2l1NG5ZNGFvb3dKdUNIdz09
-
   - summary: NumPy Community Call
     description: |
       A fortnightly meeting to share updates on everything


### PR DESCRIPTION
This was discussed at the last NumPy community meeting - the earlier time works better for regular attendees.

Also some minor cleanup removing a one-off meeting from the calendar now that it has passed.