### PR TITLE
Update to Hugo v112 API

### DIFF
--- a/layouts/partials/post_meta/project_meta.html
+++ b/layouts/partials/post_meta/project_meta.html
@@ -3,7 +3,7 @@
   <table>
     {{ $meta_fields := (slice "homepage" "repository" "pypi" "libraries-io" "license" "license-type") }}
     {{- range $attr := $meta_fields -}}
-      {{ $val := $.Params.Get $attr }}
+      {{ $val := index $.Params $attr }}
       <tr class="field">
         <td class="field-name">
           {{ $attr | humanize }}:
@@ -22,7 +22,7 @@
   <ul class="endorsed-specs-list">
     {{- range $specs -}}
       {{ if not (in (lower .Title) "meta") }}
-        {{ if in (.Params.Get "endorsed-by") $root.File.BaseFileName }}
+        {{ if in ( index .Params "endorsed-by" ) $root.File.BaseFileName }}
           <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
         {{- end }}
       {{- end }}

--- a/layouts/partials/post_meta/spec_meta.html
+++ b/layouts/partials/post_meta/spec_meta.html
@@ -4,7 +4,7 @@
   <table>
     {{ $meta_fields := (slice "author" "discussion" "history" "endorsed-by") }}
     {{- range $attr := $meta_fields -}}
-      {{ $val := $.Params.Get $attr }}
+      {{ $val := index $.Params $attr }}
       {{ $attr := strings.TrimPrefix "spec_" $attr }}
       {{- if eq $attr "author" }}
         {{ $attr = "authors" }}

--- a/layouts/partials/specs/spec_list.html
+++ b/layouts/partials/specs/spec_list.html
@@ -13,7 +13,7 @@
           </a>
         </td>
         <td class="spec__status">
-          {{- $endorsed_by := .Params.Get "endorsed-by" }}
+          {{- $endorsed_by := index .Params "endorsed-by" }}
           {{- $N := len (or $endorsed_by "") }}
           {{- if ge $N 2 }}
             {{- range $idx, $el := $endorsed_by  }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   PYTHON_VERSION = "3.8" # netlify currently only support 2.7 and 3.8
-  HUGO_VERSION = "0.111.3"
+  HUGO_VERSION = "0.112.1"
 
 [[plugins]]
   package = "netlify-plugin-checklinks"


### PR DESCRIPTION
`.Params.Get $key` has been deprecated; use `index .Params $key` instead.

See https://github.com/gohugoio/hugo/issues/10862#issuecomment-1559990324