### PR TITLE
Generate JSON with core project information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help prepare html serve serve-dev clean calendars teams teams-clean
+.PHONY: help prepare html serve serve-dev clean calendars teams teams-clean core-project-json
 .DEFAULT_GOAL := help
 SHELL:=/bin/bash
 
@@ -42,11 +42,16 @@ teams-clean:
 
 teams: | teams-clean $(patsubst %,$(TEAMS_DIR)/%.md,$(TEAMS)) ## generates team gallery pages
 
+core-project-json: content/specs/core-projects/core-projects.json
 
-html: prepare calendars ## build the website in ./public
+content/specs/core-projects/core-projects.json: content/specs/core-projects/[^_]*.md
+	@echo "Generating project JSON: $@"
+	@python tools/md-header-to-json.py $? > $@
+
+html: prepare calendars core-project-json ## build the website in ./public
 	@hugo
 
-serve: prepare calendars ## serve the website
+serve: prepare calendars core-project-json ## serve the website
 	@hugo --printI18nWarnings server
 
 serve-dev: prepare calendars

--- a/tools/md-header-to-json.py
+++ b/tools/md-header-to-json.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import yaml
+import json
 
 files = sys.argv[1:]
 
@@ -15,4 +16,4 @@ for mdfile in files:
         header = yaml.load("".join(data), Loader=yaml.SafeLoader)
         out.append(header)
 
-print(yaml.dump(out))
+print(json.dumps(out, indent=2))

--- a/tools/md-header-to-json.py
+++ b/tools/md-header-to-json.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import yaml
+
+files = sys.argv[1:]
+
+out = []
+for mdfile in files:
+    with open(mdfile) as f:
+        data = f.readlines()
+        end_header = data[1:].index("---\n") + 1
+        data = data[1:end_header]
+        header = yaml.load("".join(data), Loader=yaml.SafeLoader)
+        out.append(header)
+
+print(yaml.dump(out))


### PR DESCRIPTION
/cc @Carreau @bsipocz 

Maybe output file should be `index.json`, since the URL will then be:

https://scientific-python.org/specs/core-projects/index.json