### PR TITLE
Add a Zoom link to the description attribute

### DIFF
--- a/calendars/contributor-experience.yaml
+++ b/calendars/contributor-experience.yaml
@@ -5,7 +5,7 @@ events:
       A weekly meeting to discuss everything related to contributor experience. Everyone is welcome to attend and contribute to a conversation.
 
       Join us via Zoom: https://numfocus-org.zoom.us/j/81082067424?pwd=bVNqWXhqSXZEdTl6ZzFsa1lJZ08xZz09
-      
+
     begin: 2023-03-30 13:00:00 +00:00
     end: 2023-03-30 14:00:00 +00:00
     url: https://numfocus-org.zoom.us/j/81082067424?pwd=bVNqWXhqSXZEdTl6ZzFsa1lJZ08xZz09

--- a/calendars/contributor-experience.yaml
+++ b/calendars/contributor-experience.yaml
@@ -3,6 +3,9 @@ events:
   - summary: Contributor Experience Project Community Call
     description: |
       A weekly meeting to discuss everything related to contributor experience. Everyone is welcome to attend and contribute to a conversation.
+
+      Join us via Zoom: https://numfocus-org.zoom.us/j/81082067424?pwd=bVNqWXhqSXZEdTl6ZzFsa1lJZ08xZz09
+      
     begin: 2023-03-30 13:00:00 +00:00
     end: 2023-03-30 14:00:00 +00:00
     url: https://numfocus-org.zoom.us/j/81082067424?pwd=bVNqWXhqSXZEdTl6ZzFsa1lJZ08xZz09


### PR DESCRIPTION
The link in the url attribute isn't visible to subscribers of the calendar. To mitigate the issue, I'm adding it to the description.