### PR TITLE
Update Zoom links in numpy.yaml

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -9,10 +9,10 @@ events:
       To add to the meeting agenda the topics you’d like to discuss,
       follow the link: https://hackmd.io/76o-IxCjQX2mOXO_wwkcpg
 
-      Join us via Zoom: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
+      Join us via Zoom: https://numfocus-org.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
     begin: 2022-11-23 17:00:00 +00:00
     end: 2022-11-23 18:00:00 +00:00
-    url: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
+    url: https://numfocus-org.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years
@@ -27,10 +27,10 @@ events:
       Please notify us of an issue or PR that you’d like to have triaged/reviewed by adding
       a GitHub link to it in the meeting agenda: https://hackmd.io/68i_JvOYQfy9ERiHgXMPvg
 
-      Join us via Zoom: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
+      Join us via Zoom: https://numfocus-org.zoom.us/j/82096749952?pwd=MW9oUmtKQ1c3a2gydGk1RTdYUUVXZz09
     begin: 2023-01-11 17:00:00 +00:00
     end: 2023-01-11 18:00:00 +00:00
-    url: https://us06web.zoom.us/j/82096749952?pwd=MW9oUmtKQ1c3a2gydGk1RTdYUUVXZz09
+    url: https://numfocus-org.zoom.us/j/82096749952?pwd=MW9oUmtKQ1c3a2gydGk1RTdYUUVXZz09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years
@@ -46,10 +46,10 @@ events:
       To add to the meeting agenda the topics you'd like to discuss,
       follow the link: https://hackmd.io/oB_boakvRqKR-_2jRV-Qjg
 
-      Join us via Zoom: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
+      Join us via Zoom: https://numfocus-org.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
     begin: 2022-11-07 12:00:00 +00:00
     end: 2022-11-07 13:00:00 +00:00
-    url: https://us06web.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
+    url: https://numfocus-org.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years
@@ -65,10 +65,10 @@ events:
       To add to the meeting agenda the topics you'd like to discuss,
       follow the link: https://hackmd.io/oB_boakvRqKR-_2jRV-Qjg
 
-      Join us via Zoom: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
+      Join us via Zoom: https://numfocus-org.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
     begin: 2022-11-21 16:00:00 +00:00
     end: 2022-11-21 17:00:00 +00:00
-    url: https://us06web.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
+    url: https://numfocus-org.zoom.us/j/85016474448?pwd=TWEvaWJ1SklyVEpwNXUrcHV1YmFJQT09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years
@@ -82,10 +82,10 @@ events:
       To add to the meeting agenda the topics you’d like to discuss,
       follow the link: https://hackmd.io/3f3otyyuTte3FU9y3QzsLg
 
-      Join us via Zoom: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
+      Join us via Zoom: https://numfocus-org.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
     begin: 2023-01-26 12:00:00 +00:00
     end: 2023-01-26 13:00:00 +00:00
-    url: https://us06web.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
+    url: https://numfocus-org.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years
@@ -99,10 +99,10 @@ events:
       To add to the meeting agenda the topics you’d like to discuss,
       follow the link: https://hackmd.io/3f3otyyuTte3FU9y3QzsLg
 
-      Join us via Zoom: https://us06web.zoom.us/j/83278611437?pwd=ekhoLzlHRjdWc0NOY2FQM0NPemdkZz09
+      Join us via Zoom: https://numfocus-org.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
     begin: 2022-10-20 20:00:00 +00:00
     end: 2022-10-20 21:00:00 +00:00
-    url: https://us06web.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
+    url: https://numfocus-org.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
     repeat:
       interval:
         # seconds, minutes, hours, days, weeks, months, years


### PR DESCRIPTION
Changing Zoom links to the new format that shows a name of the org that owns the Zoom license. 