### PR TITLE
Add link to meetings notes for networkx dispatching

### DIFF
--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -20,6 +20,7 @@ events:
       Discuss NetworkX dispatching development and plugins such as GraphBLAS, cugraph, and nx-parallel.
 
       Meeting link: https://anaconda.zoom.us/j/94192874965?pwd=K0wvcmhXem41ZlVSQ2l4TXlUaDgxdz09
+      Meeting notes: https://hackmd.io/rqs_pWMxSLmICXCpI3w-Ug
       Zoom meeting ID: 941 9287 4965
       Zoom meeting passcode: 572126
     begin: 2023-07-27 07:00:00


### PR DESCRIPTION
Followup to #459. @MridulS reminded me that we _do_ have meeting notes for this meeting