### PR TITLE
Add Specs meeting to the calendar

### DIFF
--- a/calendars/specs.yaml
+++ b/calendars/specs.yaml
@@ -1,0 +1,13 @@
+name: SPEC Steering Committee
+timezone: UTC
+events:
+  - summary: SPEC Planning Meeting
+    description: |
+      This is the monthly meeting for the SPECs Steering Committee.
+
+      Meeting Link:  https://ucsc.zoom.us/j/98441337155?pwd=Mjl6TjdRTTNBc3ZGQzE3MTQyRVkyZz09
+      Meeting notes: https://hackmd.io/WPTkRnNtSOeF7OhUTRHDwA
+    begin: 2023-09-05 16:00:00
+    end: 2023-09-05 17:00:00
+    url: https://ucsc.zoom.us/j/98441337155?pwd=Mjl6TjdRTTNBc3ZGQzE3MTQyRVkyZz09
+    ics: RRULE:FREQ=MONTHLY;BYDAY=1TU;INTERVAL=1


### PR DESCRIPTION
I added the SPECs meeting to the Scientific Python calendar. (I will update the zoom link once we have the account set up).