### PR TITLE
custom.css: (code) Remove color

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -105,10 +105,6 @@ table.spec__table thead {
   font-weight: bold;
 }
 
-code {
-  color: #004811;
-}
-
 .endorse-icon {
   width: 1.5rem;
   margin-right: 0.25rem;


### PR DESCRIPTION
This was overriding the theme's color for this element, which interferes with the upcoming dark mode for the theme.

See https://github.com/scientific-python/scientific-python-hugo-theme/pull/233#issuecomment-1721643948 by @jarrodmillman.