### PR TITLE
Change: (.spec-meta) background

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -61,7 +61,7 @@ table.spec__table thead {
 }
 
 .spec-meta {
-  background: #eee;
+  background: var(--colorNoteBackground);
   padding: 0.5rem;
   display: inline-block;
   margin-top: 0.5rem;


### PR DESCRIPTION
This fixes the color of this class with regard to the theme's
dark-mode PR: <https://github.com/scientific-python/scientific-python-hugo-theme/pull/233>.

See <https://github.com/scientific-python/scientific-python-hugo-theme/pull/233#issuecomment-1726365166>.