### PR TITLE
Fix: (.spec-meta) Background for dark-mode

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -61,7 +61,7 @@ table.spec__table thead {
 }
 
 .spec-meta {
-  background: #eee;
+  background: var(--colorBlockBackground);
   padding: 0.5rem;
   display: inline-block;
   margin-top: 0.5rem;


### PR DESCRIPTION
This fixes the appearance of the `.spec-meta` class's background color in dark mode.

This should be merged when the theme submodule is updated to include <https://github.com/scientific-python/scientific-python-hugo-theme/pull/233>.

This supersedes https://github.com/scientific-python/scientific-python.org/pull/485.

### Tasks

1. [x] Merge theme update
2. [x] Rebase and push this PR's branch
3. [x] Check deploy preview
4. [x] Merge this PR