### PR TITLE
Update the NumPy Optimization Team meetings schedule

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -66,8 +66,8 @@ events:
       follow the link: https://hackmd.io/dVdSlQ0TThWkOk0OkmGsmw
 
       Join us via Zoom: https://numfocus-org.zoom.us/j/88162122074?pwd=a3h0cTZubzlLcTZzMVhCL1AxUVFMdz09
-    begin: 2023-08-07 16:00:00 +00:00
-    end: 2023-08-07 17:00:00 +00:00
+    begin: 2023-11-20 16:00:00 +00:00
+    end: 2023-11-20 17:00:00 +00:00
     url: https://numfocus-org.zoom.us/j/88162122074?pwd=a3h0cTZubzlLcTZzMVhCL1AxUVFMdz09
     repeat:
       interval:


### PR DESCRIPTION
There will be no meeting on Oct 30th. Updating the schedule to reflect this change.