### PR TITLE
Add support for externally hosted calendars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,13 @@ $(CALENDAR_DIR):
 	mkdir -p $(CALENDAR_DIR)
 
 $(CALENDAR_DIR)/%.ics: calendars/%.yaml $(CALENDAR_DIR)
-	yaml2ics $< > $@
+	@if [[ -z "$(shell grep -E 'external-ics:' $<)" ]]; then \
+	  echo "yaml2ics $< > $@"; \
+	  yaml2ics $< > $@; \
+	else \
+	  echo "python tools/fetch-external-ics.py $< > $@"; \
+	  python tools/fetch-external-ics.py $< > $@; \
+	fi
 
 CALENDAR_SOURCES = $(wildcard calendars/*.yaml)
 calendars: $(subst calendars,$(CALENDAR_DIR),$(CALENDAR_SOURCES:.yaml=.ics))

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -148,6 +148,10 @@ table.spec__table thead {
   font-style: italic;
 }
 
+.calendar-list {
+  padding-top: 1rem;
+}
+
 .calendar-list .calendar {
   padding-bottom: 1rem;
 }

--- a/calendars/pandas.yaml
+++ b/calendars/pandas.yaml
@@ -1,0 +1,2 @@
+name: Pandas Community Calendar
+external-ics: https://calendar.google.com/calendar/ical/pgbn14p6poja8a1cf2dv2jhrmg%40group.calendar.google.com/public/basic.ics

--- a/layouts/calendars/list.html
+++ b/layouts/calendars/list.html
@@ -23,6 +23,7 @@
           {{ $url := (index $value "external-ics") | default (printf "%s%s.ics" $pageLink $key) }}
           <div class="calendar">
             <a href="{{ $url }}">{{ if isset $value "external-ics" }}<i class="fa fa-external-link" aria-hidden="true"></i>&nbsp;{{ end }}{{ .name }}</a>
+            {{ if isset $value "external-ics" }}(<i class="fas fa-sync"></i> {{ now.Format "2006/01/02" }}){{ end }}
             <i class="fa-regular fa-copy calendar-copy"
                onclick="navigator.clipboard.writeText('{{ $url }}');" >
             </i>

--- a/layouts/calendars/list.html
+++ b/layouts/calendars/list.html
@@ -4,7 +4,7 @@
 
 <section class="content-padding flex-row">
     <div class="shortcuts-container">
-	<div><i class="fa-solid fa-list"></i> On this page</div>
+        <div><i class="fa-solid fa-list"></i> On this page</div>
         <div id="shortcuts"></div>
     </div>
     <div class="content-container">
@@ -20,12 +20,12 @@
 
         <div class="calendar-list">
           {{ range $key, $value := $.Site.Data.calendars }}
-          <div class="calendar"><a href="{{ $key }}.ics">{{ .name }}</a>
-            <img
-              class="calendar-copy"
-              src="/images/content_copy.svg"
-              onclick="navigator.clipboard.writeText('{{ printf "%s%s.ics" $pageLink $key }}');"
-            />
+          {{ $url := (index $value "external-ics") | default (printf "%s%s.ics" $pageLink $key) }}
+          <div class="calendar">
+            <a href="{{ $url }}">{{ if isset $value "external-ics" }}<i class="fa fa-external-link" aria-hidden="true"></i>&nbsp;{{ end }}{{ .name }}</a>
+            <i class="fa-regular fa-copy calendar-copy"
+               onclick="navigator.clipboard.writeText('{{ $url }}');" >
+            </i>
             {{ range .events }}
             <div class="calendar-event">{{ .summary }}</div>
             {{ end }}
@@ -56,13 +56,13 @@
                 eventSources: [
                 {{ range $key, $value := $.Site.Data.calendars }}
                     {
-                        url: '{{ $key }}.ics',
-                        format: 'ics',
-                        color: cal_colors.shift(),
+                      url: '{{ $key }}.ics',
+                      format: 'ics',
+                      color: cal_colors.shift(),
                     },
                 {{ end }}
                 ],
-                eventClick: function(info) {
+              eventClick: function(info) {
                     info.jsEvent.preventDefault();
                     alert('Event: ' + info.event.title + '\n' + info.event.extendedProps.description + '\n' + 'URL: ' +info.event.url);
                 },

--- a/tools/fetch-external-ics.py
+++ b/tools/fetch-external-ics.py
@@ -1,0 +1,9 @@
+import yaml
+import requests
+import sys
+
+
+data = yaml.load(open(sys.argv[1]), Loader=yaml.SafeLoader)
+url = data["external-ics"]
+
+print(requests.get(url).content.decode("utf-8"))

--- a/tools/fetch-external-ics.py
+++ b/tools/fetch-external-ics.py
@@ -1,9 +1,9 @@
 import yaml
-import requests
+import urllib.request
 import sys
 
 
 data = yaml.load(open(sys.argv[1]), Loader=yaml.SafeLoader)
 url = data["external-ics"]
 
-print(requests.get(url).content.decode("utf-8"))
+print(urllib.request.urlopen(url).read().decode("utf-8"))


### PR DESCRIPTION
- Use a different compile path for local and remotely stored calendars
- Render external links on the calendar download page, but use internal links for JS calendar displayt
- Add Pandas's calendar

@melissawm This is the alternative pathway I had in mind for https://github.com/scientific-python/yaml2ics/pull/71 and https://github.com/scientific-python/scientific-python.org/issues/246

The one problem with this approach (and any approach, in fact) is that our calendar rendering won't update when pandas changes their ICS. I tried to make the widget render from the remote URL, but that causes CORS problems.

Given that their calendar may frequently be out of date, does it make sense to host it here—or at least, include it in the calendar widget? Is there a reason why they don't want to use the YAML infrastructure provided?