### PR TITLE
Use olson time zone identifier

### DIFF
--- a/calendars/graphblas.yaml
+++ b/calendars/graphblas.yaml
@@ -1,5 +1,5 @@
 name: GraphBLAS Community Calendar
-timezone: US/Pacific
+timezone: America/Los_Angeles
 events:
   - summary: Python-graphblas Community Call
     description: |

--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -1,5 +1,5 @@
 name: NetworkX Community Calendar
-timezone: US/Pacific
+timezone: America/Los_Angeles
 events:
   - summary: NetworkX Community Call (Americas/Oceania)
     description: |

--- a/calendars/specs.yaml
+++ b/calendars/specs.yaml
@@ -1,5 +1,5 @@
 name: SPEC Steering Committee
-timezone: UTC
+timezone: America/Los_Angeles
 events:
   - summary: SPEC Planning Meeting
     description: |
@@ -7,7 +7,7 @@ events:
 
       Meeting Link:  https://ucsc.zoom.us/j/98441337155?pwd=Mjl6TjdRTTNBc3ZGQzE3MTQyRVkyZz09
       Meeting notes: https://hackmd.io/WPTkRnNtSOeF7OhUTRHDwA
-    begin: 2023-09-05 16:00:00
-    end: 2023-09-05 17:00:00
+    begin: 2023-09-05 9:00:00
+    end: 2023-09-05 10:00:00
     url: https://ucsc.zoom.us/j/98441337155?pwd=Mjl6TjdRTTNBc3ZGQzE3MTQyRVkyZz09
     ics: RRULE:FREQ=MONTHLY;BYDAY=1TU;INTERVAL=1


### PR DESCRIPTION
We were getting this error:
```
10:46:28 PM: git submodule update --init
10:46:28 PM: ((python -c "import yaml2ics" && pre-commit) > /dev/null 2>&1) || pip install -q -r requirements.txt
10:46:53 PM: test -f .git/hooks/pre-commit || pre-commit install
10:46:53 PM: pre-commit installed at .git/hooks/pre-commit
10:46:53 PM: yaml2ics calendars/xarray.yaml > content/calendars/xarray.ics
10:46:53 PM: yaml2ics calendars/scipy.yaml > content/calendars/scipy.ics
10:46:53 PM: yaml2ics calendars/matplotlib.yaml > content/calendars/matplotlib.ics
10:46:53 PM: yaml2ics calendars/graphblas.yaml > content/calendars/graphblas.ics
10:46:53 PM: Traceback (most recent call last):
10:46:53 PM:   File "/opt/buildhome/python3.8/bin/yaml2ics", line 8, in <module>
10:46:53 PM:     sys.exit(main())
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/yaml2ics.py", line 200, in main
10:46:53 PM:     print(calendar.serialize())
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/component.py", line 68, in serialize
10:46:53 PM:     return self.to_container(context).serialize()
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/component.py", line 63, in to_container
10:46:53 PM:     return ComponentMeta.BY_TYPE[type(self)].serialize_toplevel(self, context)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/converter/component.py", line 172, in serialize_toplevel
10:46:53 PM:     self._serialize_attrs(component, context, container)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/converter/types/calendar.py", line 44, in _serialize_attrs
10:46:53 PM:     super()._serialize_attrs(component, context, container)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/converter/component.py", line 179, in _serialize_attrs
10:46:53 PM:     conv.serialize(component, container, context)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/converter/component.py", line 57, in serialize
10:46:53 PM:     output.append(value.to_container(context))
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/component.py", line 63, in to_container
10:46:53 PM:     return ComponentMeta.BY_TYPE[type(self)].serialize_toplevel(self, context)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/converter/component.py", line 172, in serialize_toplevel
10:46:53 PM:     self._serialize_attrs(component, context, container)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/converter/component.py", line 179, in _serialize_attrs
10:46:53 PM:     conv.serialize(component, container, context)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/converter/types/timespan.py", line 122, in serialize
10:46:53 PM:     dt_value = dt_conv.serialize(value.get_begin(), params, context)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/valuetype/datetime.py", line 154, in serialize
10:46:53 PM:     return self._serialize_dt(value, params, context)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/valuetype/datetime.py", line 48, in _serialize_dt
10:46:53 PM:     tz = Timezone.from_tzinfo(value.tzinfo, context)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/timezone/__init__.py", line 148, in from_tzinfo
10:46:53 PM:     return Timezone_from_tzinfo(tzinfo, context)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/timezone/converters.py", line 74, in Timezone_from_tzinfo
10:46:53 PM:     tz = func(tzinfo)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/timezone/converters.py", line 136, in Timezone_from_dateutil
10:46:53 PM:     return Timezone.from_tzid(filename)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/timezone/__init__.py", line 140, in from_tzid
10:46:53 PM:     return Timezone_from_tzid(tzid)
10:46:53 PM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/ics/timezone/converters.py", line 44, in Timezone_from_tzid
10:46:53 PM:     raise ValueError(f"no vTimezone.ics file found for {tzid}")
10:46:53 PM: ValueError: no vTimezone.ics file found for /usr/share/zoneinfo/US/Pacific
10:46:53 PM: make: *** [Makefile:23: content/calendars/graphblas.ics] Error 1
10:46:55 PM: Failed during stage "building site": Build script returned non-zero exit code: 2
```