### PR TITLE
change video link for sparse meeting

### DIFF
--- a/calendars/sparse-array.yaml
+++ b/calendars/sparse-array.yaml
@@ -3,7 +3,7 @@ timezone: America/Los_Angeles
 events:
   - summary: Sparse Array Work Session
     description: |
-      Meeting Link:  https://framatalk.org/sp-sparse-arrays
+      Meeting Link:  https://meet.google.com/jrp-qgcf-nxh
       Meeting notes: https://hackmd.io/9UCjKdRUTEeoS8KdQNll-A
     begin: 2024-01-08 11:00:00
     end: 2024-01-08 12:00:00


### PR DESCRIPTION
framatalk not available amymore. Switch to google meet link.
