### PR TITLE
Update calendar js

### DIFF
--- a/layouts/calendars/list.html
+++ b/layouts/calendars/list.html
@@ -31,10 +31,10 @@
 
         <br>
         <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
-        <link href='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.0/main.min.css' rel='stylesheet' />
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/ical.js/1.4.0/ical.min.js"></script>
-        <script src='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.0/main.min.js'></script>
-        <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@5.11.0/main.global.min.js"></script>
+        <link href='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.5/main.min.css' rel='stylesheet' />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ical.js/1.5.0/ical.min.js"></script>
+        <script src='https://cdn.jsdelivr.net/npm/fullcalendar@5.11.5/main.min.js'></script>
+        <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@5.11.5/main.global.min.js"></script>
 
         <script>
           document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
We should investigate upgrading to https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/, but that will involve more work and testing.