### PR TITLE
Remove custom styling for spec icons

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -59,11 +59,6 @@ table.spec__table thead {
   vertical-align: top;
 }
 
-.endorse-icon {
-  width: 1.5rem;
-  margin-right: 0.25rem;
-}
-
 .gallery {
   display: flex;
   flex-wrap: wrap;

--- a/layouts/partials/specs/spec_list.html
+++ b/layouts/partials/specs/spec_list.html
@@ -23,7 +23,7 @@
               {{ $project_page := $.GetPage (printf "core-projects/%s" $el) }}
               {{ $url := $project_page.RelPermalink }}
               <a href="{{ $url }}">
-                <img title="{{ $project_page.Title }}" src="{{ $project_page.Params.avatar }}" class="endorse-icon"/>
+                <img title="{{ $project_page.Title }}" src="{{ $project_page.Params.avatar }}" class="icon"/>
               </a>
             {{ end }}
           {{ else }}


### PR DESCRIPTION
With the next theme update, this would otherwise look like:
![2024-02-27T16:22:44,881123148-08:00](https://github.com/scientific-python/scientific-python.org/assets/123428/c3e9cb24-2715-4b3d-a80b-9ed21b0288f4)

Now we will use the theme' standard icon styling:
```
.icon {
  align-items: center;
  display: inline-flex;
  justify-content: center;
  height: 1.5rem;
  width: 1.5rem;
}
```
I will move it from bulma.css to style.css and may add
```
  margin-right: 0.25rem;
```