### PR TITLE
Cancel SciPy NCM for Friday March 29, 2024

### DIFF
--- a/calendars/scipy.yaml
+++ b/calendars/scipy.yaml
@@ -65,3 +65,17 @@ events:
         # seconds, minutes, hours, days, weeks, months, years
         days: 56
       until: 2025-01-01 00:00:00 +00:00
+
+  - summary: [CANCELED] Monthly SciPy New Contributor Meeting (Americas)
+    description: |
+      The monthly call for new contributors to SciPy 🎉
+
+      This is the Americas-friendly meeting.
+
+      Please join us next month!
+
+      Meeting notes: https://hackmd.io/@melissawm/H15ahr5wq
+
+    begin: 2024-03-29 20:00:00 +00:00
+    end: 2024-03-29 21:00:00 +00:00
+    url: https://hackmd.io/@melissawm/H15ahr5wq

--- a/calendars/scipy.yaml
+++ b/calendars/scipy.yaml
@@ -66,7 +66,7 @@ events:
         days: 56
       until: 2025-01-01 00:00:00 +00:00
 
-  - summary: [CANCELED] Monthly SciPy New Contributor Meeting (Americas)
+  - summary: (CANCELED) Monthly SciPy New Contributor Meeting (Americas)
     description: |
       The monthly call for new contributors to SciPy 🎉
 


### PR DESCRIPTION
Title says it all - sorry for the late notice!
