### PR TITLE
DOC: adding confirmed participants as of 05/04

### DIFF
--- a/content/summits/developer/2024/_index.md
+++ b/content/summits/developer/2024/_index.md
@@ -107,10 +107,25 @@ scikit-HEP.
 
 {{< details "**List of participants** (we add names to the list as they confirm attendance)" >}}
 
+- Ariel Rokem ()
 - Brigitta Sipőcz ([@bsipocz](https://github.com/bsipocz))
+- CJ Carey ()
+- Dan McCloy ()
+- Dan Schult ()
+- Eric Larson ()
+- Guen Prawiroatmodjo ()
 - Jarrod Millman ([@jarrodmillman](https://github.com/jarrodmillman))
+- Juanita Gomez ()
+- Kyle Sunden ()
+- Lars Grüter ()
+- Madicken Munk (
 - Matthias Bussonnier ([@Carreau](https://github.com/Carreau))
+- Nabil Freij ()
+- Nick Smith ()
+- Pamphile Roy ()
 - Stéfan van der Walt ([@stefanv](https://github.com/stefanv))
+- Thomas Fan ()
+- Tim Head ()
 
 {{< /details >}}
 


### PR DESCRIPTION
I haven't yet found the script to generate the github username links, but perfect is the enemy of good, so I would say to go ahead with this and we can always fill out the details with the next batch of confirmations either with a script or manually.