### PR TITLE
DOC: move summit dates to subtitle

### DIFF
--- a/content/summits/developer/2023/_index.md
+++ b/content/summits/developer/2023/_index.md
@@ -1,8 +1,8 @@
 ---
 title: 2023 Developer Summit
 subtitle: |
-The First Scientific Python Developer Summit
-22-26 May 2023 -- Seattle, WA
+  The First Scientific Python Developer Summit
+  22-26 May 2023 -- Seattle, WA
 summary: |
   The first Scientific Python Developer Summit (May 22-26, 2023) will be hosted by the eScience Institute at the University of Washington. The week-long summit will bring together forty participants, who will develop shared infrastructure for libraries in the Scientific Python ecosystem.
 authors: ["Brigitta Sipőcz", "K. Jarrod Millman", "Stéfan van der Walt"]

--- a/content/summits/developer/2023/_index.md
+++ b/content/summits/developer/2023/_index.md
@@ -1,6 +1,8 @@
 ---
 title: 2023 Developer Summit
-subtitle: The First Scientific Python Developer Summit
+subtitle: |
+The First Scientific Python Developer Summit
+22-26 May 2023 -- Seattle, WA
 summary: |
   The first Scientific Python Developer Summit (May 22-26, 2023) will be hosted by the eScience Institute at the University of Washington. The week-long summit will bring together forty participants, who will develop shared infrastructure for libraries in the Scientific Python ecosystem.
 authors: ["Brigitta Sipőcz", "K. Jarrod Millman", "Stéfan van der Walt"]

--- a/content/summits/developer/2024/_index.md
+++ b/content/summits/developer/2024/_index.md
@@ -1,8 +1,8 @@
 ---
 title: 2024 Developer Summit
 subtitle: |
-The Second Scientific Python Developer Summit
-3-5 June 2024 – Seattle, WA
+  The Second Scientific Python Developer Summit
+  3-5 June 2024 – Seattle, WA
 summary: |
   The second Scientific Python Developer Summit (June 3-5, 2024) will be hosted by the eScience Institute at the University of Washington. The week-long summit will bring together forty participants, who will develop shared infrastructure for libraries in the Scientific Python ecosystem.
 authors: ["Brigitta Sipőcz", "K. Jarrod Millman", "Stéfan van der Walt"]

--- a/content/summits/developer/2024/_index.md
+++ b/content/summits/developer/2024/_index.md
@@ -1,6 +1,8 @@
 ---
-title: 2024 Developer Summit – June 3-5 – Seattle, WA
-subtitle: The Second Scientific Python Developer Summit
+title: 2024 Developer Summit
+subtitle: |
+The Second Scientific Python Developer Summit
+3-5 June 2024 – Seattle, WA
 summary: |
   The second Scientific Python Developer Summit (June 3-5, 2024) will be hosted by the eScience Institute at the University of Washington. The week-long summit will bring together forty participants, who will develop shared infrastructure for libraries in the Scientific Python ecosystem.
 authors: ["Brigitta Sipőcz", "K. Jarrod Millman", "Stéfan van der Walt"]


### PR DESCRIPTION
The dates should be in a prominent place, but may be not in the title as that field is harvested into the index page, too.

<img width="989" alt="Screenshot 2024-04-05 at 15 30 32" src="https://github.com/scientific-python/scientific-python.org/assets/6788290/00bcd2a0-5cb3-4933-a16b-eb3511ec4fa4">
