### PR TITLE
Disable relative URLs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,6 @@ baseURL: "https://scientific-python.org"
 languageCode: en-us
 theme: scientific-python-hugo-theme
 DefaultContentLanguage: en
-relativeURLs: true
 disableKinds: ["term", "taxonomy"]
 markup:
   highlight:


### PR DESCRIPTION
Not sure why we enabled this. But my understanding is this is not recommended.

It states here https://gohugo.io/content-management/urls/#relative-urls
```
Do not enable this option unless you are creating a serverless site, navigable via the file system.
```