### PR TITLE
Update the schedule of NumPy Newcomers' Hour

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -83,8 +83,8 @@ events:
       follow the link: https://hackmd.io/3f3otyyuTte3FU9y3QzsLg
 
       Join us via Zoom: https://numfocus-org.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
-    begin: 2023-01-26 12:00:00 +00:00
-    end: 2023-01-26 13:00:00 +00:00
+    begin: 2024-06-13 12:00:00 +00:00
+    end: 2024-06-13 13:00:00 +00:00
     url: https://numfocus-org.zoom.us/j/82563808729?pwd=ZFU3Z2dMcXBGb05YemRsaGE1OW5nQT09
     repeat:
       interval:


### PR DESCRIPTION
The next NumPy Newcomers' Hour in the 12 pm UTC slot will be held on June 13th.