### PR TITLE
Update the schedule of NumPy Optimization Team meetings

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -66,8 +66,8 @@ events:
       follow the link: https://hackmd.io/dVdSlQ0TThWkOk0OkmGsmw
 
       Join us via Zoom: https://numfocus-org.zoom.us/j/81261288210?pwd=iwV99tGSjR61RTGEERKM4QKxe46g1n.1
-    begin: 2023-11-20 17:00:00 +00:00
-    end: 2023-11-20 18:00:00 +00:00
+    begin: 2024-06-03 17:00:00 +00:00
+    end: 2024-06-03 18:00:00 +00:00
     url: https://numfocus-org.zoom.us/j/88162122074?pwd=a3h0cTZubzlLcTZzMVhCL1AxUVFMdz09
     repeat:
       interval:

--- a/content/summits/developer/2024/_index.md
+++ b/content/summits/developer/2024/_index.md
@@ -146,7 +146,6 @@ scikit-HEP.
 - Thomas Fan ([@thomasjpfan](https://github.com/thomasjpfan))
 - Tim Head ([@betatim](https://github.com/betatim))
 
-
 {{< /details >}}
 
 ## Goals


### PR DESCRIPTION
We are moving this team meeting to the following Monday, June 3rd, due to a public holiday in the US.