### PR TITLE
MAINT: remove summit news from frontpage

### DIFF
--- a/content/news.md
+++ b/content/news.md
@@ -1,6 +1,6 @@
 ---
 title: News
-newsHeader: Second Developer Summit was held in Seattle – June 2-5, 2024
+newsHeader: Second Developer Summit held in Seattle – June 2-5, 2024
 date: 2024-06-06
 sidebar: false
 ---

--- a/content/news.md
+++ b/content/news.md
@@ -1,5 +1,7 @@
 ---
 title: News
+newsHeader: Second Developer Summit was held in Seattle – June 2-5, 2024
+date: 2024-06-06
 sidebar: false
 ---
 

--- a/content/news.md
+++ b/content/news.md
@@ -1,7 +1,5 @@
 ---
 title: News
-newsHeader: Second Developer Summit will be held in Seattle – June 2-5, 2024
-date: 2024-04-11
 sidebar: false
 ---
 


### PR DESCRIPTION
Summit has been held, remove announcement highlight from front page.

(I'm not sure if this works but will need CI for checking it as I cannot build the site locally)