### PR TITLE
Shift sparse array meeting up 1 week (off labor day)

### DIFF
--- a/calendars/sparse-array.yaml
+++ b/calendars/sparse-array.yaml
@@ -6,9 +6,13 @@ events:
       Meeting Link:  https://meet.google.com/jrp-qgcf-nxh
       Meeting notes: https://hackmd.io/9UCjKdRUTEeoS8KdQNll-A
     begin: 2024-01-08 11:00:00
-    end: 2024-01-08 12:00:00
-    url: https://framatalk.org/sp-sparse-arrays
+    duration: { minutes: 60 }
+    url: https://meet.google.com/jrp-qgcf-nxh
     repeat:
       interval:
         days: 14
       until: 2025-12-31 00:00:00
+      except_on:
+        - 2024-09-02 11:00:00
+      also_on:
+        - 2024-08-26 11:00:00


### PR DESCRIPTION
Shifting the labor day meeting to one week earlier.
This seems to work locally with yaml2ics and then importing to google calendar.
