### PR TITLE
Make SPEC draft status explicit

### DIFF
--- a/layouts/partials/specs/spec_list.html
+++ b/layouts/partials/specs/spec_list.html
@@ -16,18 +16,17 @@
           </a>
         </td>
         <td class="spec__status">
-          {{- $endorsed_by := index .Params "endorsed-by" }}
-          {{- $N := len (or $endorsed_by "") }}
-          {{- if ge $N 2 }}
-            {{- range $idx, $el := $endorsed_by  }}
-              {{ $project_page := $.GetPage (printf "core-projects/%s" $el) }}
-              {{ $url := $project_page.RelPermalink }}
-              <a href="{{ $url }}">
-                <img title="{{ $project_page.Title }}" src="{{ $project_page.Params.avatar }}" class="icon"/>
-              </a>
-            {{ end }}
+          {{ if (index .Params "is-draft") }}
+          DRAFT
           {{ else }}
-            DRAFT
+          {{- $endorsed_by := index .Params "endorsed-by" }}
+          {{- range $idx, $el := $endorsed_by  }}
+          {{ $project_page := $.GetPage (printf "core-projects/%s" $el) }}
+          {{ $url := $project_page.RelPermalink }}
+          <a href="{{ $url }}">
+            <img title="{{ $project_page.Title }}" src="{{ $project_page.Params.avatar }}" class="icon"/>
+          </a>
+          {{ end }}
           {{ end -}}
         </td>
       </tr>

--- a/layouts/partials/specs/spec_meta.html
+++ b/layouts/partials/specs/spec_meta.html
@@ -27,8 +27,8 @@
 {{- end -}}
 {{- $specMetaBody := partial "_elements/field-list.html" (dict "entries" $fieldList) -}}
 
-{{/* Add warning if SPEC not endorsed */}}
-{{- if not $endorsed }}
+{{/* Add draft warning */}}
+{{- if (index $.Params "is-draft") }}
   {{- $title := "attention" -}}
   {{- $body := "This is a draft document." -}}
   {{- $admonition := partial "_elements/admonition.html" (dict "title" $title "body" $body) -}}


### PR DESCRIPTION
Now need to specify `is-draft: true` in template, for it to render as draft.

Closes #667 

Will need to update the SPEC repo with `is-draft` flags, and also change template to have `is-draft: true` for new SPECs. See https://github.com/scientific-python/specs/pull/336.