### PR TITLE
MAINT: cleanup language

### DIFF
--- a/content/summits/_index.md
+++ b/content/summits/_index.md
@@ -3,9 +3,10 @@ title: "Summits"
 date: 2022-08-04
 ---
 
-The developer summits address topics of interest across several packages (e.g.,
-sparse arrays, benchmarking, packaging, teaching, specific science domains).
-The summits are recorded and shared on our youtube channel under the
-[“Developer Discussions” playlist](https://www.youtube.com/playlist?list=PL7rNFJDy0iz5GGSmRQNMO-qF6PUG3YsQx).
+The developer summits address topics of interest across several packages (e.g., sparse arrays, benchmarking, packaging, teaching, specific science domains).
+While we also organize some more topic focused developer discussions e.g for the _Domain stacks_ or _Sparse Data_.
+
+We have recordings for some of the developer summit preparation calls, as well as for some more specialized topics.
+They are shared on our youtube channel under the [“Developer Discussions” playlist](https://www.youtube.com/playlist?list=PL7rNFJDy0iz5GGSmRQNMO-qF6PUG3YsQx).
 
 To discuss upcoming summits or suggest potential summit topics, see the [summits category in the discussion forum](https://discuss.scientific-python.org/c/summits/27).


### PR DESCRIPTION
as we don't record the hands-on developer summits.

Please feel free to edit the exact wording, I'm not exactly happy with it but wanted to fix the factually incorrect premise of the current text.