### PR TITLE
MAINT: Updated networkx calendar

### DIFF
--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -1,19 +1,18 @@
 name: NetworkX Community Calendar
-timezone: America/Los_Angeles
 events:
-  - summary: NetworkX Community Call (Americas/Oceania)
+  - summary: NetworkX Community Call
     description: |
       The NetworkX Community Call.
 
       Meeting Link:  https://colgate.zoom.us/j/92619161786
       Meeting notes: https://hackmd.io/ea2IhUuqSrG4kM9tokXuEw
-    begin: 2023-05-17 11:00:00
-    end: 2023-05-17 12:00:00
+    begin: 2023-05-17 18:00:00 +00:00
+    end: 2023-05-17 19:00:00 +00:00
     url: https://colgate.zoom.us/j/92619161786
     repeat:
       interval:
         days: 7
-      until: 2025-12-31 00:00:00
+      until: 2025-12-31 00:00:00 +00:00
 
   - summary: NetworkX Dispatching Call
     description: |
@@ -23,10 +22,24 @@ events:
       Meeting notes: https://hackmd.io/rqs_pWMxSLmICXCpI3w-Ug
       Zoom meeting ID: 941 9287 4965
       Zoom meeting passcode: 572126
-    begin: 2024-05-29 10:00:00
-    end: 2024-05-29 11:00:00
+    begin: 2024-05-29 17:00:00 +00:00
+    end: 2024-05-29 18:00:00 +00:00
     url: https://anaconda.zoom.us/j/94192874965?pwd=K0wvcmhXem41ZlVSQ2l4TXlUaDgxdz09
     repeat:
       interval:
         days: 7
-      until: 2025-12-31 00:00:00
+      until: 2025-12-31 00:00:00 +00:00
+
+  - summary: nx-parallel call
+    description: |
+      Discussing the future of the nx-parallel backend.
+
+      Meeting link: https://colgate.zoom.us/j/281534728
+      Meeting notes: https://hackmd.io/BkTLclPh0
+    begin: 2024-09-13 15:30:00 +00:00
+    end: 2024-09-13 16:30:00 +00:00
+    url: https://colgate.zoom.us/j/281534728
+    repeat:
+      interval:
+        days: 7
+      until: 2025-12-31 00:00:00 +00:00

--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -30,9 +30,9 @@ events:
         days: 7
       until: 2025-12-31 00:00:00 +00:00
 
-  - summary: nx-parallel call
+  - summary: "NetworkX's nx-parallel backend call"
     description: |
-      Discussing the future of the nx-parallel backend.
+      Discussing the future of the nx-parallel backend (https://github.com/networkx/nx-parallel).
 
       Meeting link: https://colgate.zoom.us/j/281534728
       Meeting notes: https://hackmd.io/BkTLclPh0


### PR DESCRIPTION
- Added nx-parallel meeting(timings selected based on https://crab.fit/nxparallel-meeting-timings-198086)
- switched from America/Los_Angeles to UTC

@dschult @MridulS 

Thank you :)