### PR TITLE
CAL: Shift NX Community meetings to Thursdays

### DIFF
--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -6,20 +6,6 @@ events:
 
       Meeting Link:  https://colgate.zoom.us/j/92619161786
       Meeting notes: https://hackmd.io/ea2IhUuqSrG4kM9tokXuEw
-    begin: 2023-05-17 18:00:00 +00:00
-    end: 2023-05-17 19:00:00 +00:00
-    url: https://colgate.zoom.us/j/92619161786
-    repeat:
-      interval:
-        days: 7
-      until: 2024-09-25 00:00:00 +00:00
-
-  - summary: NetworkX Community Call
-    description: |
-      The NetworkX Community Call.
-
-      Meeting Link:  https://colgate.zoom.us/j/92619161786
-      Meeting notes: https://hackmd.io/ea2IhUuqSrG4kM9tokXuEw
     begin: 2024-10-03 18:00:00 +00:00
     end: 2024-10-03 19:00:00 +00:00
     url: https://colgate.zoom.us/j/92619161786

--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -12,6 +12,20 @@ events:
     repeat:
       interval:
         days: 7
+      until: 2024-09-25 00:00:00 +00:00
+
+  - summary: NetworkX Community Call
+    description: |
+      The NetworkX Community Call.
+
+      Meeting Link:  https://colgate.zoom.us/j/92619161786
+      Meeting notes: https://hackmd.io/ea2IhUuqSrG4kM9tokXuEw
+    begin: 2024-10-03 18:00:00 +00:00
+    end: 2024-10-03 19:00:00 +00:00
+    url: https://colgate.zoom.us/j/92619161786
+    repeat:
+      interval:
+        days: 7
       until: 2025-12-31 00:00:00 +00:00
 
   - summary: NetworkX Dispatching Call


### PR DESCRIPTION
Changing the day of the week for NetworkX Community calls to Thursday. Same time.
I left the old time up until Sept 24 so it shows history in the calendar, but could remove that.