### PR TITLE
Move skimage community call to 18:00 UTC

### DIFF
--- a/calendars/skimage.yaml
+++ b/calendars/skimage.yaml
@@ -6,9 +6,9 @@ events:
 
       Meeting notes: https://hackmd.io/@scientific-python/HJWUBDVNi
       Archive: https://github.com/scikit-image/meeting-notes
-    begin: 2022-09-13 17:00:00 +00:00
-    end: 2022-09-13 18:00:00 +00:00
-    url: https://us06web.zoom.us/j/88060567580?pwd=THRpaWFnSFNwK0Fycy9FVk5RYnV5UT09
+    begin: 2022-09-13 18:00:00 +00:00
+    duration: { minutes: 60 }
+    url: https://meet.evolix.org/skimage-meeting
     repeat:
       interval:
         days: 14


### PR DESCRIPTION
to avoid a conflict with the [SPEC meeting](https://github.com/scientific-python/scientific-python.org/blob/1c4f1acf4576acbd52c419ee6cd9a734d86b4650/calendars/specs.yaml). Because both events are defined in different timezones, both happen at the same time with the recent shift to winter time in "America/Los_Angeles".

We might want to standardize on UTC to avoid this going forward.

cc @stefanv 