### PR TITLE
Fix expired repeat for  matplotlib calender

### DIFF
--- a/calendars/matplotlib.yaml
+++ b/calendars/matplotlib.yaml
@@ -12,11 +12,7 @@ events:
     begin: 2022-03-24 21:00:00
     end: 2022-03-24 22:00:00
     url: https://zoom.us/j/384435716?pwd=WFpxVWxoYXArTDFzN1lWaHNoOE8xZz09
-    repeat:
-      interval:
-        # seconds, minutes, hours, days, weeks, months, years
-        days: 7
-      until: 2025-01-01 00:00:00
+    ics: RRULE:FREQ=WEEKLY;BYDAY=TH
 
   - summary: Matplotlib Monthly New Contributors Meeting (Americas)
     description: |


### PR DESCRIPTION
the weekly meetings repeat expired last week so updated it because the meetings are still ongoing.