### PR TITLE
Add 2025 summit page stub

### DIFF
--- a/content/summits/developer/2025/_index.md
+++ b/content/summits/developer/2025/_index.md
@@ -1,0 +1,154 @@
+---
+title: 2024 Developer Summit
+subtitle: |
+  The Third Scientific Python Developer Summit
+  11-15 May 2025 – Seattle, WA
+summary: |
+  The third Scientific Python Developer Summit (May 11-15, 2024) will be hosted by the eScience Institute at the University of Washington. The week-long summit will bring together forty participants, who will develop shared infrastructure for libraries in the Scientific Python ecosystem.
+authors: ["Brigitta Sipőcz", "K. Jarrod Millman", "Stéfan van der Walt"]
+date: 2024-03-05
+---
+
+## During the event
+
+Coming soon.
+
+## Agenda
+
+<style type="text/css">
+table {
+  margin-left: 0 !important;
+}
+</style>
+
+{{< details "**Saturday**" >}}
+| Time | Description |
+|------|-------------|
+| | Arrive |
+{{< /details >}}
+
+{{< details "**Sunday**" >}}
+| Time | Description |
+|------|-------------|
+| 09:00 | Meet at eScience |
+{{< /details >}}
+
+{{< details "**Monday**" >}}
+| Time | Description |
+|------|-------------|
+| 09:00 | Meet at eScience |
+{{< /details >}}
+
+{{< details "**Tuesday**" >}}
+| Time | Description |
+|------|-------------|
+| 09:00 | Meet at eScience |
+{{< /details >}}
+
+{{< details "**Wednesday**" >}}
+| Time | Description |
+|------|-------------|
+| 09:00 | Meet at eScience |
+{{< /details >}}
+
+</div>
+
+The event is held at the [eScience Institute, UW Physics/Astronomy Tower, 6th Floor, 3910 15th Ave NE, Seattle](https://goo.gl/maps/EfkoHtvZad3fYMx77).
+
+_A friendly reminder that we are guests of the eScience Institute, and
+that some members of their research staff will continue working in the space
+during our event._
+
+<br/>
+<iframe
+  src="https://www.google.com/maps/d/embed?mid=1eWqjU_k7dkYF8Z58sNQ9zJaYbR8HXPM&ehbc=2E312F"
+  width="100%" height="480"
+>
+</iframe>
+
+## Logistics
+
+We have space for 40 participants for three days and four nights.
+This will be an invite-only event that requires upfront agreement to:
+(a) take part in one or more pre-summit planning meetings,
+(b) collaborate with fellow participants on a work plan,
+(c) attend the summit in-person, and
+(d) participate, to whatever degree possible, in several months of post-summit implementation.
+
+### Airport to hotel
+
+There is no need to get a rental car or taxi/ride-share, as the airport and the UW campus area is well-served by bus and rail.
+We recommend using Link Light Rail to get from the airport to the hotel. It takes approximately an hour and costs $3.25.
+The closest station to the hotel is "U-District" (0.3mi away), which is a new station opened in 2021 and is not to be confused with the station in Downtown called, "University St", neither with "University of Washington".
+
+### Food
+
+Coming soon
+
+### Participants
+
+Participants are recruited from the community of developers of packages
+such as NumPy, SciPy, matplotlib, xarray, pandas, scikit-image, scikit-learn,
+NetworkX, and IPython, as well as domain stacks including Astropy, Pangeo, and
+scikit-HEP.
+
+{{< details "**List of participants** (we add names to the list as they confirm attendance)" >}}
+
+- Brigitta Sipőcz ([@bsipocz](https://github.com/bsipocz))
+- Jarrod Millman ([@jarrodmillman](https://github.com/jarrodmillman))
+- Stéfan van der Walt ([@stefanv](https://github.com/stefanv))
+
+{{< /details >}}
+
+## About
+
+### Goals
+
+The Scientific Python Developer Summit provides an opportunity for core developers
+from the scientific Python ecosystem to come together to:
+
+#### 1. Improve joint infrastructure
+
+Collaborate to adopt and improve infrastructure, tools, and processes
+used across projects. This includes infrastructure already described
+in Scientific Python Ecosystem Coordination documents (SPECs), as well
+as, but not limited to, tools for documentation, testing, benchmarking,
+packaging, and Continuous Integration (CI).
+
+#### 2. Better coordination of the ecosystem
+
+A central goal of the Scientific Python project and, by implication, the summit, is to better coordinate maintenance of the different projects.
+
+#### 3. Work on shared strategic goals
+
+A strategic plan would identify core needs and future challenges of the scientific Python community.
+Rather than focusing on the technical details of one particular project or domain area, the strategic plan would discuss the challenges shared across projects and domains.
+The plan can be used by the community as supporting evidence when applying for grants.
+
+### Dates
+
+The summit is held May 11-15, 2024 in Seattle, WA.
+
+Attendees should preferably arrive the day before the summit starts, and stay for the entire duration of the summit.
+
+### Pre-Summit Planning
+
+See [planning issues](https://github.com/scientific-python/summit-2025/issues).
+
+Participants will be responsible for attending two or more one-hour video meetings (the planning meetings mentioned above) and for
+participating in a planning repository via PRs, issues—as both contributors and reviewers.
+There is no heavy top-down structure: participants themselves will organize the work that needs to be done ahead of time.
+They will decide on topics, divide the work, and schedule the meeting.
+
+### Summit Execution
+
+The goal of the summit is to be a hands-on work meeting.
+That said, there will be some free time scheduled to brainstorm new ideas, and to discuss current community projects and activities.
+
+### Post-Summit Implementation
+
+After the meeting, attendees will collaborate on their assigned tasks until completion.
+
+## Meeting notes
+
+To be posted.

--- a/content/summits/developer/2025/_index.md
+++ b/content/summits/developer/2025/_index.md
@@ -5,7 +5,13 @@ subtitle: |
   11-15 May 2025 – Seattle, WA
 summary: |
   The third Scientific Python Developer Summit (May 11-15, 2025) will be hosted by the eScience Institute at the University of Washington. The week-long summit will bring together forty participants, who will develop shared infrastructure for libraries in the Scientific Python ecosystem.
-authors: ["Brigitta Sipőcz", "K. Jarrod Millman", "Kirstie Whitaker", "Stéfan van der Walt"]
+authors:
+  [
+    "Brigitta Sipőcz",
+    "K. Jarrod Millman",
+    "Kirstie Whitaker",
+    "Stéfan van der Walt",
+  ]
 date: 2025-03-05
 ---
 
@@ -113,7 +119,9 @@ scikit-HEP.
 
 ### Goals
 
-The Scientific Python Developer Summit provides an opportunity for core developers
+The 2025 Scientific Python Developer Summit will focus on statistics, optimization, sparse data, plotting, and dataframes.
+
+The Developer Summit provides an opportunity for core developers
 from the scientific Python ecosystem to come together to:
 
 #### 1. Improve joint infrastructure

--- a/content/summits/developer/2025/_index.md
+++ b/content/summits/developer/2025/_index.md
@@ -1,12 +1,12 @@
 ---
-title: 2024 Developer Summit
+title: 2025 Developer Summit
 subtitle: |
   The Third Scientific Python Developer Summit
   11-15 May 2025 – Seattle, WA
 summary: |
-  The third Scientific Python Developer Summit (May 11-15, 2024) will be hosted by the eScience Institute at the University of Washington. The week-long summit will bring together forty participants, who will develop shared infrastructure for libraries in the Scientific Python ecosystem.
-authors: ["Brigitta Sipőcz", "K. Jarrod Millman", "Stéfan van der Walt"]
-date: 2024-03-05
+  The third Scientific Python Developer Summit (May 11-15, 2025) will be hosted by the eScience Institute at the University of Washington. The week-long summit will bring together forty participants, who will develop shared infrastructure for libraries in the Scientific Python ecosystem.
+authors: ["Brigitta Sipőcz", "K. Jarrod Millman", "Kirstie Whitaker", "Stéfan van der Walt"]
+date: 2025-03-05
 ---
 
 ## During the event
@@ -66,6 +66,14 @@ during our event._
 >
 </iframe>
 
+## Funding
+
+Unlike previous years, participation costs for this year's summit are covered
+only for those invited as part of the special track on statistics (for that, we have targeted grant funding).
+
+Project maintainers, please reach out to your individual projects to determine
+whether they have funds to sponsor your attendance.
+
 ## Logistics
 
 We have space for 40 participants for three days and four nights.
@@ -96,6 +104,7 @@ scikit-HEP.
 
 - Brigitta Sipőcz ([@bsipocz](https://github.com/bsipocz))
 - Jarrod Millman ([@jarrodmillman](https://github.com/jarrodmillman))
+- Kirstie Whitaker ([@KirstieJane](https://github.com/KirstieJane))
 - Stéfan van der Walt ([@stefanv](https://github.com/stefanv))
 
 {{< /details >}}
@@ -127,7 +136,7 @@ The plan can be used by the community as supporting evidence when applying for g
 
 ### Dates
 
-The summit is held May 11-15, 2024 in Seattle, WA.
+The summit is held May 11-15, 2025 in Seattle, WA.
 
 Attendees should preferably arrive the day before the summit starts, and stay for the entire duration of the summit.
 


### PR DESCRIPTION
This is a stub for the 2025 summit webpage. Details will be filled in with follow-up PRs. I also created this repo for issue planning: https://github.com/scientific-python/summit-2025