### PR TITLE
Updated nx-parallel meetings' timing and notes link in `networkx.yaml`

### DIFF
--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -33,8 +33,8 @@ events:
       Discussing the future of the nx-parallel backend (https://github.com/networkx/nx-parallel).
 
       Meeting link: https://colgate.zoom.us/j/281534728
-      Meeting notes: https://hackmd.io/BkTLclPh0
-    begin: 2025-02-14 15:30:00Z
+      Meeting notes: https://hackmd.io/tF0saJhyQ2i25e8tWiBrmw
+    begin: 2025-05-15 13:00:00Z
     duration: { minutes: 60 }
     url: https://colgate.zoom.us/j/281534728
     repeat:


### PR DESCRIPTION
cc @dschult @dPys @akshitasure12