### PR TITLE
Update schedule of NumPy triage meetings

### DIFF
--- a/calendars/numpy.yaml
+++ b/calendars/numpy.yaml
@@ -28,8 +28,8 @@ events:
       a GitHub link to it in the meeting agenda: https://hackmd.io/68i_JvOYQfy9ERiHgXMPvg
 
       Join us via Zoom: https://numfocus-org.zoom.us/j/82096749952?pwd=MW9oUmtKQ1c3a2gydGk1RTdYUUVXZz09
-    begin: 2025-04-02 17:00:00 +00:00
-    end: 2025-04-02 18:00:00 +00:00
+    begin: 2025-07-23 17:00:00 +00:00
+    end: 2025-07-23 18:00:00 +00:00
     url: https://numfocus-org.zoom.us/j/82096749952?pwd=MW9oUmtKQ1c3a2gydGk1RTdYUUVXZz09
     repeat:
       interval:


### PR DESCRIPTION
Updates the schedule of NumPy triage meetings as the 2025-07-09 meeting has been canceled.