### PR TITLE
Renaming SP calendar

### DIFF
--- a/calendars/scientific-python.yaml
+++ b/calendars/scientific-python.yaml
@@ -1,4 +1,4 @@
-name: Scientific Python Learn & Lectures
+name: Scientific Python Community Calls
 events:
   - summary: Scientific Python Learn & Lectures sites
     description: |


### PR DESCRIPTION
I think it would be nice to have a Scientific Python Community calls and list all open SP events under it. 


(I would also think it's useful to explicitly list the interval, even if the default works fine.