### PR TITLE
CAL: SPEC meeting is now bimonthly

### DIFF
--- a/calendars/specs.yaml
+++ b/calendars/specs.yaml
@@ -1,5 +1,4 @@
 name: SPEC Steering Committee
-timezone: America/Los_Angeles
 events:
   - summary: SPEC Planning Meeting
     description: |
@@ -7,7 +6,7 @@ events:
 
       Meeting Link:  https://ucsc.zoom.us/j/98441337155?pwd=Mjl6TjdRTTNBc3ZGQzE3MTQyRVkyZz09
       Meeting notes: https://hackmd.io/WPTkRnNtSOeF7OhUTRHDwA
-    begin: 2025-10-07 9:00:00
-    end: 2025-10-07 10:00:00
+    begin: 2025-10-07 16:00:00
+    end: 2025-10-07 17:00:00
     url: https://ucsc.zoom.us/j/98441337155?pwd=Mjl6TjdRTTNBc3ZGQzE3MTQyRVkyZz09
     ics: RRULE:FREQ=MONTHLY;BYDAY=1TU;INTERVAL=2


### PR DESCRIPTION
@stefanv - is there a way to keep the old entry (e.g. an `end` field that shows when the last entry is rather than when the end of the individual meeting is) and add a new one with the same name?