### PR TITLE
CAL: adding meeting links to SP learn meeting

### DIFF
--- a/calendars/scientific-python.yaml
+++ b/calendars/scientific-python.yaml
@@ -4,6 +4,9 @@ events:
     description: |
       Discussions around how to organize learning material for
       Scientific Python.
+
+      Meeting Link: https://washington.zoom.us/j/92404931842
+      Meeting notes: https://hackmd.io/zVZtDmAvRduUY5zg0giMkg?both
     begin: 2025-07-15 16:00:00 +00:00
     duration: { minutes: 60 }
     url: https://washington.zoom.us/j/92404931842
@@ -15,7 +18,6 @@ events:
       maintaiend within the Scientific Python Project.
 
       Meeting Link:  https://caltech.zoom.us/meetings/86722664109/invitations?signature=-8E86H4IwZALVvlVrwg20JPQcpqM1yoJsycGDcrYS18
-
       Meeting notes: https://hackmd.io/@bsipocz/SP_tools_meeting
     begin: 2025-09-02 16:00:00 +00:00
     duration: { minutes: 60 }


### PR DESCRIPTION
So we have nice links in the individual calendar entries such as we have for SPECs meeting:

<img width="444" height="346" alt="Screenshot 2025-08-19 at 09 13 48" src="https://github.com/user-attachments/assets/15b86fa7-5bdd-4de2-a7fa-b9bd23633c01" />
<img width="433" height="277" alt="Screenshot 2025-08-19 at 09 13 57" src="https://github.com/user-attachments/assets/26f7810b-732d-47b8-8d88-b046e078e271" />
