### PR TITLE
CAL: have the direct zoom link not the invitation

### DIFF
--- a/calendars/scientific-python.yaml
+++ b/calendars/scientific-python.yaml
@@ -17,7 +17,7 @@ events:
       Bimonthly community meeting to discuss and work on tools hosted and
       maintaiend within the Scientific Python Project.
 
-      Meeting Link:  https://caltech.zoom.us/meetings/86722664109/invitations?signature=-8E86H4IwZALVvlVrwg20JPQcpqM1yoJsycGDcrYS18
+      Meeting Link:  https://caltech.zoom.us/j/86722664109
       Meeting notes: https://hackmd.io/@bsipocz/SP_tools_meeting
     begin: 2025-09-02 16:00:00 +00:00
     duration: { minutes: 60 }


### PR DESCRIPTION
Fixing up the Tools meeting entry, it should be the zoom link listed not an invite page link