### PR TITLE
Add developer summit description and criteria

### DIFF
--- a/content/summits/developer/_index.md
+++ b/content/summits/developer/_index.md
@@ -3,15 +3,17 @@ title: "Developer Summits"
 ---
 
 Scientific Python Developer Summits are focused, in-person, invitation-only gatherings of core developers and maintainers from across the ecosystem.
-These are working meetings---not beginner-oriented events---and they typically do not include talks or tutorials.
-Instead, summits provide a collaborative and self-organized space to make progress on shared technical challenges, strengthen coordination between projects, and advance the long-term sustainability of the ecosystem.
-
+These are working meetings---not beginner- or newcomer-oriented events---and they typically do not include talks or tutorials.
+Instead, summits provide a collaborative and self-organized space to address shared technical challenges, strengthen coordination between projects, and support the long-term sustainability of the ecosystem.
 Participants coordinate in advance to identify priorities and plan concrete work, ensuring that in-person time is spent effectively.
-Work at summits often involves improving joint infrastructure (e.g., testing, packaging, documentation), aligning developer practices (e.g., governance, release management, community guides), and developing a shared strategic plan to guide the future of scientific Python.
+Work at summits often involves improving shared infrastructure (e.g., testing, packaging, documentation), aligning developer practices (e.g., governance, release management, community guides), and developing a collective strategic vision for the future of scientific Python.
 
-To qualify as a Developer Summit, the event should:
+For an event to be considered a Developer Summit, it should:
 
 - Convene core developers and maintainers from multiple scientific Python projects.
-- Be participant-driven and self-organized, with priorities set by attendees.
-- Allocate time for both concrete technical work and higher-level strategic planning.
-- Focus on issues with cross-project impact rather than those of a single package.
+- Be participant-driven and self-organized, with priorities defined by attendees.
+- Provide time for substantial collaborative technical work, while also leaving space for higher-level discussions where relevant.
+- Focus on issues with cross-project impact, rather than narrowly scoped tasks that impact only a single package or work that one person could reasonably pursue independently.
+
+The Scientific Python project welcomes and endorses many forms of collaborative events and developer meetings.
+However, to preserve a clear scope and shared understanding, only gatherings that meet the above criteria should be referred to as a **Scientific Python Developer Summit**.


### PR DESCRIPTION
This is a first pass at formalizing what a "Scientific Python Developer Summit" is.

On the summit landing page https://scientific-python.org/summits/ it states:
```
The developer summits address topics of interest across several packages
(e.g., sparse arrays, benchmarking, packaging, teaching, specific science domains).
While we also organize some more topic focused developer discussions,
e.g., for the Domain stacks or Sparse Data.
```

That text needs some work. And we will also need to start formalizing what a  "Scientific Python Domain Stack Summit" and/or a "Scientific Python Topic Summit". We can do that in a future PR or we can expand this PR.