### PR TITLE
Adjust timezone for items on the scientific-python calendars page

### DIFF
--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -1,5 +1,4 @@
 name: NetworkX Community Calendar
-timezone: America/New_York
 events:
   - summary: NetworkX Community Call
     description: |
@@ -7,13 +6,13 @@ events:
 
       Meeting link: https://colgate.zoom.us/j/92619161786
       Meeting notes: https://hackmd.io/ea2IhUuqSrG4kM9tokXuEw
-    begin: 2025-05-29 12:00:00
+    begin: 2025-05-29 12:00:00 -04:00
     duration: { minutes: 60 }
     url: https://colgate.zoom.us/j/92619161786
     repeat:
       interval:
         days: 7
-      until: 2026-12-31 00:00:00
+      until: 2026-12-31 00:00:00 -04:00
 
   - summary: NetworkX Dispatching Call
     description: |
@@ -23,7 +22,7 @@ events:
       Meeting notes: https://hackmd.io/rqs_pWMxSLmICXCpI3w-Ug
       Zoom meeting ID: 941 9287 4965
       Zoom meeting passcode: 572126
-    begin: 2025-02-25 11:30:00
+    begin: 2025-02-25 11:30:00 -04:00
     duration: { minutes: 60 }
     url: https://anaconda.zoom.us/j/94192874965?pwd=K0wvcmhXem41ZlVSQ2l4TXlUaDgxdz09
     ics: RRULE:FREQ=MONTHLY;BYDAY=1TU;INTERVAL=1

--- a/calendars/sparse-array.yaml
+++ b/calendars/sparse-array.yaml
@@ -1,17 +1,16 @@
 name: Sparse Arrays WG
-timezone: America/Los_Angeles
 events:
   - summary: Sparse Array Work Session
     description: |
       Meeting Link:  https://meet.google.com/jrp-qgcf-nxh
       Meeting notes: https://hackmd.io/9UCjKdRUTEeoS8KdQNll-A
-    begin: 2024-01-08 11:00:00
+    begin: 2024-01-08 11:00:00 -07:00
     duration: { minutes: 60 }
     url: https://meet.google.com/jrp-qgcf-nxh
     repeat:
       interval:
         days: 14
-      until: 2025-12-31 00:00:00
+      until: 2026-12-31 00:00:00
       except_on:
         - 2024-09-02 11:00:00
       also_on:

--- a/calendars/sparse-array.yaml
+++ b/calendars/sparse-array.yaml
@@ -4,14 +4,11 @@ events:
     description: |
       Meeting Link:  https://meet.google.com/jrp-qgcf-nxh
       Meeting notes: https://hackmd.io/9UCjKdRUTEeoS8KdQNll-A
+
     begin: 2024-01-08 11:00:00 -07:00
     duration: { minutes: 60 }
     url: https://meet.google.com/jrp-qgcf-nxh
     repeat:
       interval:
         days: 14
-      until: 2026-12-31 00:00:00
-      except_on:
-        - 2024-09-02 11:00:00
-      also_on:
-        - 2024-08-26 11:00:00
+      until: 2026-12-31 00:00:00 -07:00


### PR DESCRIPTION
Take out explicit timezone setting in the yaml for NX and sparse array meetings. I'm told this will allow the calendar times in the HTML version of the calendar shown on scientific-python.org, calendar page be shown correctly for timezones other than the one being set in the yaml file.

The cost of not setting the "timezone" is that the times need to specify a UTC offset. But that's pretty minor.

Note that the calendar subscriptions show it correctly and the ICS files too. Just the html monthly picture seems to show it incorrectly.  You can check this by looking at the NetworkX weekly meeting which occurs at 12 EDT on Thursdays, but apparently shows as 12 also for people who are in other timezones. Similarly for the sparse arrays meeting which is at 11 PDT but shows as 11 in the html calendar no matter what the timezone of the viewer is.