### PR TITLE
update networkx calendar events

### DIFF
--- a/calendars/networkx.yaml
+++ b/calendars/networkx.yaml
@@ -1,4 +1,5 @@
 name: NetworkX Community Calendar
+timezone: America/New_York
 events:
   - summary: NetworkX Community Call
     description: |
@@ -6,37 +7,37 @@ events:
 
       Meeting link: https://colgate.zoom.us/j/92619161786
       Meeting notes: https://hackmd.io/ea2IhUuqSrG4kM9tokXuEw
-    begin: 2025-05-29 13:00:00 -04:00
+    begin: 2025-05-29 12:00:00
     duration: { minutes: 60 }
     url: https://colgate.zoom.us/j/92619161786
     repeat:
       interval:
         days: 7
-      until: 2026-12-31 00:00:00 -04:00
+      until: 2027-12-31 00:00:00
 
-  - summary: NetworkX Dispatching Call
-    description: |
-      Discuss NetworkX dispatching development and backends such as GraphBLAS, cugraph, and nx-parallel.
+  # - summary: NetworkX Dispatching Call
+  #   description: |
+  #     Discuss NetworkX dispatching development and backends such as GraphBLAS, cugraph, and nx-parallel.
+  #
+  #     Meeting link: https://colgate.zoom.us/j/92619161786
+  #     Meeting notes: https://hackmd.io/rqs_pWMxSLmICXCpI3w-Ug
+  #     Zoom meeting ID: 941 9287 4965
+  #     Zoom meeting passcode: 572126
+  #   begin: 2025-02-25 11:30:00 -04:00
+  #   duration: { minutes: 60 }
+  #   url: https://anaconda.zoom.us/j/94192874965?pwd=K0wvcmhXem41ZlVSQ2l4TXlUaDgxdz09
+  #   ics: RRULE:FREQ=MONTHLY;BYDAY=1TU;INTERVAL=1
 
-      Meeting link: https://colgate.zoom.us/j/92619161786
-      Meeting notes: https://hackmd.io/rqs_pWMxSLmICXCpI3w-Ug
-      Zoom meeting ID: 941 9287 4965
-      Zoom meeting passcode: 572126
-    begin: 2025-02-25 11:30:00 -04:00
-    duration: { minutes: 60 }
-    url: https://anaconda.zoom.us/j/94192874965?pwd=K0wvcmhXem41ZlVSQ2l4TXlUaDgxdz09
-    ics: RRULE:FREQ=MONTHLY;BYDAY=1TU;INTERVAL=1
-
-  - summary: "NetworkX's nx-parallel backend call"
-    description: |
-      Discussing the future of the nx-parallel backend (https://github.com/networkx/nx-parallel).
-
-      Meeting link: https://colgate.zoom.us/j/281534728
-      Meeting notes: https://hackmd.io/tF0saJhyQ2i25e8tWiBrmw
-    begin: 2025-05-15 13:00:00Z
-    duration: { minutes: 60 }
-    url: https://colgate.zoom.us/j/281534728
-    repeat:
-      interval:
-        days: 7
-      until: 2026-12-31 00:00:00 +00:00
+  # - summary: "NetworkX's nx-parallel backend call"
+  #   description: |
+  #     Discussing the future of the nx-parallel backend (https://github.com/networkx/nx-parallel).
+  #
+  #     Meeting link: https://colgate.zoom.us/j/281534728
+  #     Meeting notes: https://hackmd.io/tF0saJhyQ2i25e8tWiBrmw
+  #   begin: 2025-05-15 13:00:00Z
+  #   duration: { minutes: 60 }
+  #   url: https://colgate.zoom.us/j/281534728
+  #   repeat:
+  #     interval:
+  #       days: 7
+  #     until: 2026-12-31 00:00:00 +00:00


### PR DESCRIPTION
remove events for networkx dispatching  and nx-parallel meetings.
update timezone handling for the main community event.