### PR TITLE
MAINT: add cooldown period for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 14
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 14
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     allow:


### PR DESCRIPTION
Noticed with the latest PR that we never actually added this cooldown here.