### PR TITLE
Switch from netlify link checker to lychee

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -29,4 +29,4 @@ accept = "100..=103,200..=299,429"
 
 # Throttle requests to avoid rate limits (e.g., upload.wikimedia.org)
 max_concurrency = 1
-request_interval = 2
+host_request_interval = "200ms"

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,0 +1,32 @@
+# Lychee link checker configuration
+# See https://lycheeverse.github.io/lychee/config.html
+
+# Exclude URLs matching these patterns (treated as regex)
+exclude = [
+  # CDN / font hosts that block automated requests
+  'fonts\.gstatic\.com',
+  'fonts\.googleapis\.com',
+  'cdn\.jsdelivr\.net',
+  'cdnjs\.cloudflare\.com',
+  'unpkg\.com',
+
+  # Sites that return 403 Forbidden to bots
+  'anaconda\.org',
+  'hackmd\.io',
+  'timeanddate\.com',
+  'medium\.com',
+]
+
+# Exclude file paths matching these patterns (treated as regex)
+# Meeting notes are historical and not actively maintained
+exclude_path = [
+  '/meeting\d+/',
+]
+
+# Accept these HTTP status codes as successful
+# 100-103: informational, 200-299: success, 429: rate limit (transient, not a real error)
+accept = "100..=103,200..=299,429"
+
+# Throttle requests to avoid rate limits (e.g., upload.wikimedia.org)
+max_concurrency = 1
+request_interval = 2

--- a/content/summits/domain-stacks/_index.md
+++ b/content/summits/domain-stacks/_index.md
@@ -8,5 +8,5 @@ In terms of data modeling, a stack would have a many-to-many relationship with p
 Another related set of questions involve what parts of already organized domain stacks should be "promoted" to the ecosystem level (i.e., Scientific Python). For example, would it make sense to merge discussion forums (using categories and tags to keep things organized); governance structures; and codes of conduct standards, reporting guidelines, and review committees.
 
 The summits bring together developers and users of specific domain stacks
-(e.g., [Pangeo](https://pangeo.io/packages.html), [Astropy](https://www.astropy.org/affiliated/index.html), [scikit-hep](https://scikit-hep.org/packages), [scverse](https://scverse.org/projects/), [NIPY](https://nipy.org/))
+(e.g., [Pangeo](https://pangeo.io/), [Astropy](https://www.astropy.org/affiliated/index.html), [scikit-hep](https://scikit-hep.org/packages), [scverse](https://scverse.org/projects/), [NIPY](https://nipy.org/))
 to discuss the shortcomings of the current documentation and organization, the needs of various scientific "domain stacks," and to develop a shared roadmap and vision for better documenting and organizing domain stack documentation and organization.

--- a/content/tools/_index.md
+++ b/content/tools/_index.md
@@ -23,7 +23,7 @@ We also list a few hosted services provided for the community.
 
 - [scientific-python-hugo-theme](https://github.com/scientific-python/scientific-python-hugo-theme)
 
-  Our [Hugo](https://gohugo.io/) theme aims to align closely with the [PyData Sphinx Theme](pydata-sphinx-theme.readthedocs.io).
+  Our [Hugo](https://gohugo.io/) theme aims to align closely with the [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io).
   It is used by [NumPy](https://numpy.org/), [SciPy](https://scipy.org/), [Scientific Python](https://scientific-python.org/), and other project sites.
 
 ### Developer utilities
@@ -62,7 +62,7 @@ See also [GitHub Actions](#github-actions) below.
 - [yaml2ics](https://github.com/scientific-python/yaml2ics)
 
   Convert plain-text descriptions of calendar events into ICS files that can be loaded into Google Calendar etc.
-  Used to host the Scientific Python [community calendars](https://scientific-python.org/calendar).
+  Used to host the Scientific Python [community calendars](https://scientific-python.org/calendars/).
 
 - [discuss.scientific-python.org](https://discuss.scientific-python.org)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,10 +14,17 @@
     export PATH=/opt/build/repo/dart-sass:$PATH && \
     python -m venv .py3 && \
     source .py3/bin/activate && \
-    make html \
+    make html && \
+    LYCHEE_TAG=$(curl -s https://api.github.com/repos/lycheeverse/lychee/releases/latest | jq -r .tag_name) && \
+    curl -LO "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_TAG}/lychee-x86_64-unknown-linux-gnu.tar.gz" && \
+    tar -xf lychee-x86_64-unknown-linux-gnu.tar.gz && \
+    ./lychee \
+      --no-progress \
+      --root-dir public \
+      --exclude 'fonts\\.gstatic\\.com' \
+      --exclude 'fonts\\.googleapis\\.com' \
+      --exclude 'cdn\\.jsdelivr\\.net' \
+      --exclude 'cdnjs\\.cloudflare\\.com' \
+      --exclude 'unpkg\\.com' \
+      public/ \
     """
-
-[[plugins]]
-  package = "netlify-plugin-checklinks"
-  [plugins.inputs]
-  skipPatterns = ['*bot*', 'https://fonts.gstatic.com', 'https://fonts.googleapis.com', 'https://cdn.jsdelivr.net', 'https://cdnjs.cloudflare.com', 'https://unpkg.com']

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,12 +19,8 @@
     curl -LO "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_TAG}/lychee-x86_64-unknown-linux-gnu.tar.gz" && \
     tar -xf lychee-x86_64-unknown-linux-gnu.tar.gz && \
     ./lychee-x86_64-unknown-linux-gnu/lychee \
+      --config .github/lychee.toml \
       --no-progress \
       --root-dir public \
-      --exclude 'fonts\\.gstatic\\.com' \
-      --exclude 'fonts\\.googleapis\\.com' \
-      --exclude 'cdn\\.jsdelivr\\.net' \
-      --exclude 'cdnjs\\.cloudflare\\.com' \
-      --exclude 'unpkg\\.com' \
       public/ \
     """

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,7 +18,7 @@
     LYCHEE_TAG=$(curl -s https://api.github.com/repos/lycheeverse/lychee/releases/latest | jq -r .tag_name) && \
     curl -LO "https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_TAG}/lychee-x86_64-unknown-linux-gnu.tar.gz" && \
     tar -xf lychee-x86_64-unknown-linux-gnu.tar.gz && \
-    ./lychee \
+    ./lychee-x86_64-unknown-linux-gnu/lychee \
       --no-progress \
       --root-dir public \
       --exclude 'fonts\\.gstatic\\.com' \


### PR DESCRIPTION
The netlify link checker hasn't been updated in years, and is now failing because of some outdated JS dependency.