### PR TITLE
Fix link checking

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -10,6 +10,9 @@ exclude = [
   'cdnjs\.cloudflare\.com',
   'unpkg\.com',
 
+  # Discourse embed URLs are only valid after a page has been published
+  'discuss\.scientific-python\.org',
+
   # Sites that return 403 Forbidden to bots
   'anaconda\.org',
   'hackmd\.io',

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -18,12 +18,16 @@ exclude = [
   'hackmd\.io',
   'timeanddate\.com',
   'medium\.com',
+
+  # Links from pages captured for posterity, but no longer active
+  'www.dsb.dk'
 ]
 
 # Exclude file paths matching these patterns (treated as regex)
 # Meeting notes are historical and not actively maintained
 exclude_path = [
   '/meeting\d+/',
+  '/*\.xml/'
 ]
 
 # Accept these HTTP status codes as successful

--- a/layouts/specs/single.html
+++ b/layouts/specs/single.html
@@ -11,7 +11,9 @@
     {{- end }}
 
     {{ .Content }}
+    {{ if isset .Params "number" }}
     {{ partial "specs/comments.html" . }}
+    {{ end }}
   </div>
   {{ partial "shortcuts.html" . }}
 </section>


### PR DESCRIPTION
- Do not check discourse discussion links (won't exist until page has been published)
- Only render discussions for SPECs themselves, not for project pages etc.