### PR TITLE
Update GraphBLAS community calendar

### DIFF
--- a/calendars/graphblas.yaml
+++ b/calendars/graphblas.yaml
@@ -1,5 +1,5 @@
 name: GraphBLAS Community Calendar
-timezone: America/Los_Angeles
+timezone: America/New_York
 events:
   - summary: Python-graphblas Community Call
     description: |
@@ -14,13 +14,13 @@ events:
       Zoom meeting ID: 972 6723 4756
       Zoom meeting passcode: 584468
 
-    begin: 2023-08-16 07:00:00
-    end: 2023-08-16 08:00:00
+    begin: 2026-08-05 11:00:00
+    duration: { minutes: 60 }
     url: https://anaconda.zoom.us/j/97267234756?pwd=Q00wSjE2dDV6NmF3eFBZSFBtVDFSQT09
     repeat:
       interval:
-        days: 7
-      until: 2025-12-31 00:00:00
+        days: 14
+      until: 2030-12-31 00:00:00
 
   - summary: GraphBLAS Monthly Community Call
     description: |


### PR DESCRIPTION
The regular meeting is changing to an hour later and to every other week (starting tomorrow). The old calendar invite had also expired (my bad! been busy with 👶 )